### PR TITLE
use .test file instead of .launch file

### DIFF
--- a/euslisp/CMakeLists.txt
+++ b/euslisp/CMakeLists.txt
@@ -41,11 +41,11 @@ endif(_make_failed)
 #rosbuild_add_executable(example examples/example.cpp)
 #target_link_libraries(example ${PROJECT_NAME})
 
-rosbuild_add_rostest(test/test-euslisp.launch)
+rosbuild_add_rostest(test/test-euslisp.test)
 rosbuild_check_for_display(disp)
 if(disp)
-  rosbuild_add_rostest(test/test-irtrobot.launch)
-  rosbuild_add_rostest(test/test-irtviewer.launch)
+  rosbuild_add_rostest(test/test-irtrobot.test)
+  rosbuild_add_rostest(test/test-irtviewer.test)
 endif(disp)
 
 


### PR DESCRIPTION
use .test file instead of .launch file ;; recently .launch files have been replaced by .test files
Is this the problem only for rosbuild environment?
