### PR TITLE
roseus: support roseus message generation on catkin_make, Issue #14

### DIFF
--- a/roseus/catkin.cmake
+++ b/roseus/catkin.cmake
@@ -4,7 +4,7 @@ project(roseus)
 
 # Load catkin and all dependencies required for this package
 # TODO: remove all from COMPONENTS that are not catkin packages.
-find_package(catkin REQUIRED COMPONENTS roslang roscpp rospack actionlib actionlib_msgs visualization_msgs tf geometry_msgs std_msgs std_srvs sensor_msgs visualization_msgs tf2_ros)
+find_package(catkin REQUIRED COMPONENTS message_generation roslang roscpp rospack actionlib actionlib_msgs visualization_msgs tf geometry_msgs std_msgs std_srvs sensor_msgs visualization_msgs tf2_ros)
 
 add_definitions(-Wall)
 #
@@ -95,18 +95,27 @@ set_target_properties(simple_execute_ref_server PROPERTIES RUNTIME_OUTPUT_DIRECT
 # rosbuild_add_rostest(test/test-multi-queue.launch)
 
 ## Generate added messages and services with any dependencies listed here
+string(RANDOM _random_string)
+set(roseus_DIR "/tmp/${_random_string}")
+file(WRITE ${roseus_DIR}/roseusConfig.cmake "
+if(NOT roshomedir)
+  include(${PROJECT_SOURCE_DIR}/cmake/roseus.cmake)
+endif()
+")
 generate_messages(
   DEPENDENCIES geometry_msgs std_msgs
 )
+set(roseus_DIR)
 
 ## LIBRARIES: libraries you create in this project that dependent projects also need
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
     DEPENDS roslang roscpp rospack actionlib actionlib_msgs visualization_msgs tf geometry_msgs std_msgs std_srvs sensor_msgs visualization_msgs actionlib_tutorials coreutils tf2_ros
-    CATKIN-DEPENDS # euslisp TODO
+    CATKIN_DEPENDS message_runtime # euslisp TODO
     INCLUDE_DIRS # TODO include
     LIBRARIES # TODO
+    CFG_EXTRAS roseus.cmake
 )
 
 install(PROGRAMS bin/roseus  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/roseus/package.xml
+++ b/roseus/package.xml
@@ -27,6 +27,7 @@
   <build_depend>std_srvs</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>visualization_msgs</build_depend>
+  <build_depend>message_generation</build_depend>
   <!-- build_depend>actionlib_tutorials</build_depend -->
 
   <run_depend>roslang</run_depend>
@@ -43,9 +44,10 @@
   <run_depend>std_srvs</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>visualization_msgs</run_depend>
+  <run_depend>message_runtime</run_depend>
   <!-- run_depend>actionlib_tutorials</run_depend -->
 
   <export>
-    <roslang cmake="${prefix}/cmake/roseus.cmake"/>
+    <message_generator>euslisp</message_generator>
   </export>
 </package>

--- a/roseus/scripts/genmsg-main-eus.l
+++ b/roseus/scripts/genmsg-main-eus.l
@@ -476,6 +476,8 @@
       (setq val (read-line (piped-fork (format nil "~A --md5 ~A" *gendeps-bin* fname)) nil nil))) ;;workaround for packages installed from source
     (when (null val) ;; some groovy/rosbuild environemnt needs this line?
       (setq val (read-line (piped-fork (format nil "PYTHONPATH=`rospack find ~A`/build/devel/lib/python2.7/dist-packages:$PYTHONPATH ~A md5 ~A/~A" pkg (if (string= (pathname-type fname) "msg") "rosmsg" "rossrv") pkg name)) nil nil)))
+    (when (null val) ;;
+      (setq val (read-line (piped-fork (format nil "python -c 'from ~A.msg import *; print ~A._md5sum'" pkg name)) nil nil)))
     (when (null val)
       (warning-message 1 "[ERROR] Could not get md5sum for ~A ~A ~A~%" pkg name fname)
       (exit -1))
@@ -565,12 +567,20 @@
   (read-line (piped-fork (format nil "rossrv show ~A/~A" pkg name)) nil))
 (defun check-msg-file (pkg name)
   (read-line (piped-fork (format nil "rosmsg show ~A/~A" pkg name)) nil))
+(defun check-action-file (pkg fname)
+  (if (or (substringp "Action.msg" fname)
+          (substringp "Feedback.msg" fname)
+          (substringp "Goal.msg" fname)
+          (substringp "Result.msg" fname)
+          (substringp "Feedback.msg" fname))
+      (probe-file (format nil "~A/action" (read-line (piped-fork (format nil "rospack find ~A" pkg)))))))
 
 (defun genmsg-eus (fname)
   (let (msgs consts def pkg name oname)
     (multiple-value-setq (pkg name) (genfile-header fname))
     ;;; https://github.com/willowgarage/catkin/issues/122
-    (unless (or (check-msg-file pkg name)
+    (unless (or (check-action-file pkg fname)
+                (check-msg-file pkg name)
 		(string= (format nil "~A/roseus/~A/~A/action_msg/~A.msg" (ros::ros-home-dir) (unix:getenv "ROS_DISTRO") pkg name) fname))
       (warning-message 1 ";; error occured when parsing ~A/msg/~A~%" pkg name)
       (return-from genmsg-eus nil))


### PR DESCRIPTION
gen ros eusmessage during catkin_make discussed in #14 
- since we did not use geneus package, we need weird code in catkin.make

```
+string(RANDOM _random_string)
+set(roseus_DIR "/tmp/${_random_string}")
+file(WRITE ${roseus_DIR}/roseusConfig.cmake "
+if(NOT roshomedir)
+  include(${PROJECT_SOURCE_DIR}/cmake/roseus.cmake)
+endif()
+")
 generate_messages(
   DEPENDENCIES geometry_msgs std_msgs
 )
+set(roseus_DIR)
```
