### PR TITLE
roseus/test/test-tf.test: tf2_buffer_server output to screen

### DIFF
--- a/roseus/test/test-tf.test
+++ b/roseus/test/test-tf.test
@@ -1,7 +1,7 @@
 <launch>
   <node name="tf_publisher_1" pkg="tf" type="static_transform_publisher" args="1 0 0 0 0 0 /MANDALAY /JUPITER 10" />
   <node name="tf_publisher_2" pkg="tf" type="static_transform_publisher" args="1 2 3 0.1 0.2 0.3 /JUPITER /TOKYO 10" />
-  <node pkg="tf2_ros" type="buffer_server" name="tf2_buffer_server" output="log">
+  <node pkg="tf2_ros" type="buffer_server" name="tf2_buffer_server" output="screen">
     <param name="buffer_size" value="1200.0"/>
   </node>
   <test test-name="eustf" pkg="roseus" type="roseus" args="$(find roseus)/test/test-tf.l"


### PR DESCRIPTION
currently it fails on ros build firm although travis said it is ok.

```
[0m[32mwait-for-transform at #<ros::time #X5cddbe8 0.000> returns t
[0m[32mswitch target to /TOKYO
[0m[32mswitch target to /JUPITER
[0m;; gc 4708923 5462400
0 gc:(4708923 5462400), vmrss:63656
[32mswitch target to /TOKYO
[0m[31m[ERROR] [1395987460.593371448]: The LookupTransform goal sent to the BufferServer did not come back in the specified time. Something is likely wrong with the server.[0m
[31m[ERROR] test (and c (eps= (norm (send c :difference-position c1)) 0) (eps= (norm (send c :difference-rotation c1)) 0)) failed ... (tf2: lookup-transform failed nil #<coordinates #X5adc3e8  1000.0 0.0 0.0 / 0.0 0.0 0.0> [0mmswitch target to /TOKYO
:63656
me #X5cddbe8 0.000&gt; returns t
```

[1] http://jenkins.ros.org/job/prerelease-hydro-jsk_roseus/ARCH_PARAM=amd64,UBUNTU_PARAM=precise,label=prerelease/
