### PR TITLE
Fix permissions on installed libraries

### DIFF
--- a/euslisp/catkin.cmake
+++ b/euslisp/catkin.cmake
@@ -86,11 +86,13 @@ endforeach()
 # libraries
 install(DIRECTORY jskeus/eus/${ARCHDIR}/lib/
   DESTINATION ${EUSDIR}/${ARCHDIR}/lib
+  USE_SOURCE_PERMISSIONS
 )
 
 # objs
 install(DIRECTORY jskeus/eus/${ARCHDIR}/obj/
   DESTINATION ${EUSDIR}/${ARCHDIR}/obj
+  USE_SOURCE_PERMISSIONS
   FILES_MATCHING PATTERN "*.l" PATTERN "*.so"  PATTERN ".svn" EXCLUDE
 )
 
@@ -137,6 +139,7 @@ install(FILES jskeus/eus/doc/jlatex/jmanual.pdf DESTINATION ${EUSDIR}/doc/jlatex
 # irteus
 install(DIRECTORY jskeus/irteus/
   DESTINATION ${EUSDIR}/../irteus
+  USE_SOURCE_PERMISSIONS
   FILES_MATCHING PATTERN "*" PATTERN ".svn" EXCLUDE
 )
 # includes


### PR DESCRIPTION
All shared-object libraries should have execute permissions.

This error was found while packaging for Fedora.
