### PR TITLE
Fix geneus groovy catkin

### DIFF
--- a/geneus/cmake/roseus.cmake
+++ b/geneus/cmake/roseus.cmake
@@ -48,7 +48,7 @@ if(NOT COMMAND rosbuild_find_ros_package) ## catkin
     file(GLOB ${arg_pkg}_SERVICE_FILES "${pkg_full_path}/srv/*.srv")
 
      if(${arg_pkg}_MESSAGE_FILES OR ${arg_pkg}_SERVICE_FILES # check if we need to compile python message. generating eusmessage depends on python message to get to  know md5sum
-        AND NOT $ENV{ROS_DISTRO} STREQUAL "groovy") 
+         AND TARGET ${arg_pkg}_generate_messages_py)
       set(_depend_generate_py ${arg_pkg}_generate_messages_py)
     else()
       set(_depend_generate_py )


### PR DESCRIPTION
upstream message files not depends on generate_messages_py on groovy/catkin environment

https://github.com/jsk-ros-pkg/jsk_roseus/issues/51
