### PR TITLE
[geneus] Check eus2 permission 

### DIFF
--- a/geneus/cmake/roseus.cmake
+++ b/geneus/cmake/roseus.cmake
@@ -210,7 +210,7 @@ rosbuild_find_ros_package(geneus)
 
 # for euslisp ros API. like roslib.load_mafest
 macro(genmanifest_eus)
-  execute_process(COMMAND find ${euslisp_PACKAGE_PATH} -name eus2
+  execute_process(COMMAND find ${euslisp_PACKAGE_PATH} -name eus2 -executable
     OUTPUT_VARIABLE _eus2_output
     RESULT_VARIABLE _eus2_failed)
   if(_eus2_failed)


### PR DESCRIPTION
check eus2 permission to avoid following error:

```
  /home/travis/ros/ws_jsk_demos/src/jsk-ros-pkg/jsk_roseus/geneus/scripts/genmsg_eus: line 7: /home/travis/ros/ws_jsk_demos/src/jsk-ros-pkg/jsk_roseus/euslisp/jskeus/eus/Linux64/bin/eus2: Permission denied
```
