### PR TITLE
set _ROSBUILD_GENERATED_MSG_FILES null before rosbuild_get_msgs

### DIFF
--- a/geneus/cmake/roseus.cmake
+++ b/geneus/cmake/roseus.cmake
@@ -245,6 +245,7 @@ macro(genmsg_eus)
     return()
   endif(_eus2_failed)
 
+  set(_ROSBUILD_GENERATED_MSG_FILES "")
   rosbuild_get_msgs(_msglist)
   set(_autogen "")
   foreach(_msg ${_msglist})


### PR DESCRIPTION
I'm not sure but geneus start failing as follows, and this PR will fix them. I'm not sure if why this happens and side effect of this patch.

```
make[3]: Leaving directory `/home/travis/ros/ws_jsk_recognition/src/jsk-ros-pkg/jsk_common/jsk_footstep_msgs/build'
make[3]: Entering directory `/home/travis/ros/ws_jsk_recognition/src/jsk-ros-pkg/jsk_common/jsk_footstep_msgs/build'
[  0%] Generating ../msg/ExecFootstepsAction.msg, ../msg/ExecFootstepsGoal.msg, ../msg/ExecFootstepsActionGoal.msg, ../msg/ExecFootstepsResult.msg, ../msg/ExecFootstepsActionResult.msg, ../msg/ExecFootstepsFeedback.msg, ../msg/ExecFootstepsActionFeedback.msg
Generating for action ExecFootsteps
[  0%] Generating ../msg/PlanFootstepsAction.msg, ../msg/PlanFootstepsGoal.msg, ../msg/PlanFootstepsActionGoal.msg, ../msg/PlanFootstepsResult.msg, ../msg/PlanFootstepsActionResult.msg, ../msg/PlanFootstepsFeedback.msg, ../msg/PlanFootstepsActionFeedback.msg
Generating for action PlanFootsteps
make[3]: Leaving directory `/home/travis/ros/ws_jsk_recognition/src/jsk-ros-pkg/jsk_common/jsk_footstep_msgs/build'
[  0%] Built target ROSBUILD_genaction_msgs
make[3]: Entering directory `/home/travis/ros/ws_jsk_recognition/src/jsk-ros-pkg/jsk_common/jsk_footstep_msgs/build'
Scanning dependencies of target ROSBUILD_gensrv_roseus_gencpp
make[3]: Leaving directory `/home/travis/ros/ws_jsk_recognition/src/jsk-ros-pkg/jsk_common/jsk_footstep_msgs/build'
[  0%] Built target ROSBUILD_gensrv_roseus_gencpp
make[3]: Entering directory `/home/travis/ros/ws_jsk_recognition/src/jsk-ros-pkg/jsk_common/jsk_footstep_msgs/build'
Scanning dependencies of target ROSBUILD_genmsg_roseus_gencpp
make[3]: Leaving directory `/home/travis/ros/ws_jsk_recognition/src/jsk-ros-pkg/jsk_common/jsk_footstep_msgs/build'
make[3]: Entering directory `/home/travis/ros/ws_jsk_recognition/src/jsk-ros-pkg/jsk_common/jsk_footstep_msgs/build'
make[3]: *** No rule to make target `/opt/ros/groovy/share/gencpp/msg/ExecFootstepsAction.msg', needed by `/home/travis/.ros/roseus/groovy/gencpp/msg/ExecFootstepsAction.l'.  Stop.
make[3]: *** Waiting for unfinished jobs....
[  0%] Generating /home/travis/.ros/roseus/groovy/gencpp/generated
[generated_eus] Writing md5sum generated file to /home/travis/.ros/roseus/groovy/gencpp/generated
make[3]: Leaving directory `/home/travis/ros/ws_jsk_recognition/src/jsk-ros-pkg/jsk_common/jsk_footstep_msgs/build'
make[2]: *** [CMakeFiles/ROSBUILD_genmsg_roseus_gencpp.dir/all] Error 2
make[2]: Leaving directory `/home/travis/ros/ws_jsk_recognition/src/jsk-ros-pkg/jsk_common/jsk_footstep_msgs/build'
make[1]: *** [all] Error 2
make[1]: INTERNAL: Exiting with 9 jobserver tokens available; should be 8!
make[1]: Leaving directory `/home/travis/ros/ws_jsk_recognition/src/jsk-ros-pkg/jsk_common/jsk_footstep_msgs/build'
make: *** [all] Error 2
```

https://s3.amazonaws.com/archive.travis-ci.org/jobs/22870368/log.txt
