### PR TITLE
add exit hook before _exit

### DIFF
--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -727,6 +727,9 @@ pointer ROSEUS_EXIT(register context *ctx,int n,pointer *argv)
     s_mapHandle.clear();
     ros::shutdown();
   }
+  pointer exithook=speval(QEXITHOOK);
+  if (exithook != NIL) {
+    ufuncall(ctx,exithook,exithook,(pointer)(ctx->vsp-n),0,n);}
   if (n==0) _exit(0);
   else _exit(ckintval(argv[0]));
 }


### PR DESCRIPTION
Add exit hook before _exit according to exit function definition in eus/lisp/c/unixcall.c.

I have one question about rosues.cpp exit.
Why cannot we use "exit" instead of "_exit"?
Actually, if I use "exit" instead of "_exit",  "double free or corruption" occurs and exiting seems to fail.