### PR TITLE
Add service persist

### DIFF
--- a/roseus/euslisp/roseus.l
+++ b/roseus/euslisp/roseus.l
@@ -51,6 +51,9 @@
                       (elt lisp::*eustop-argument* i)))))
     ))
 
+(defun ros::service-call (name val &key (persist nil))
+  (ros::service-call-raw name val persist))
+
 (setq ros::*compile-message* nil)
 
 (shadow 'object *package*)

--- a/roseus/test/add-two-ints-client.l
+++ b/roseus/test/add-two-ints-client.l
@@ -12,8 +12,12 @@
   (setq req (instance roseus::AddTwoIntsRequest :init))
   (send req :a (random 10))
   (send req :b (random 20))
-  (setq res (ros::service-call "add_two_ints" req))
-  (format t "~d + ~d = ~d~%" (send req :a) (send req :b) (send res :sum))
+  (setq before (ros::time-now))
+  (if (= (mod i 2) 0)
+      (setq res (ros::service-call "add_two_ints" req :persist t))
+    (setq res (ros::service-call "add_two_ints" req :persist nil)))
+  (setq after (ros::time-now))
+  (format t "~d + ~d = ~d~ (~A sec)~%" (send req :a) (send req :b) (send res :sum) (send (ros::time- after before) :to-sec))
   (unix:sleep 1))
 
 


### PR DESCRIPTION
add new keyword :persist to ros::service-call. if calling service-call with :persist t, the connection to the service server will be cached.

see https://github.com/jsk-ros-pkg/jsk_roseus/issues/112
