### PR TITLE
Add find_package for _generate_eus_dep_msgs

### DIFF
--- a/geneus/cmake/roseus.cmake
+++ b/geneus/cmake/roseus.cmake
@@ -45,6 +45,9 @@ if(NOT COMMAND rosbuild_find_ros_package) ## catkin
   set(ROS_PACKAGE_PATH ${euslisp_PACKAGE_PATH}:${geneus_PACKAGE_PATH}:${CMAKE_SOURCE_DIR}:$ENV{ROS_PACKAGE_PATH})
 
   macro(_generate_eus_dep_msgs arg_pkg)
+    if (NOT ${${_pkg}_FOUND})
+      find_package(${_pkg} QUIET)
+    endif()
     get_filename_component(pkg_full_path ${${arg_pkg}_DIR}/.. ABSOLUTE)
 
     set(need_compile TRUE)


### PR DESCRIPTION
(roseus.cmake) : Add find_package for _generate_eus_dep_msgs

This is related with the following issues.
Currently, `jsk_pr2eus` travis fails [2,3].
The reason is missing of msg file[1].

By adding print message, I confirmed that package information such as `${${arg_pkg}_DIR}` is empty,
so no message files are converted to `~/.ros/roseus/$ROS_DISTRO/xxx`.

If we add find_package before generation, it seems to work.

[1] https://github.com/jsk-ros-pkg/jsk_pr2eus/issues/37
[2] https://github.com/jsk-ros-pkg/jsk_pr2eus/pull/35
[3] https://travis-ci.org/jsk-ros-pkg/jsk_pr2eus/jobs/27971640
