### PR TITLE
do not compile roseus message if it could not find in find_package-ed

### DIFF
--- a/geneus/cmake/roseus.cmake
+++ b/geneus/cmake/roseus.cmake
@@ -202,6 +202,7 @@ if(NOT COMMAND rosbuild_find_ros_package) ## catkin
   endif()
   foreach(_pkg ${_depend_output})
     if(NOT ${_pkg}_GENERATE_EUS_DEP_MSGS)
+      set(need_compile TRUE)
       if(NOT ${_pkg}_FOUND)
         # workaround only for for groovy
         if($ENV{ROS_DISTRO} STREQUAL "groovy")
@@ -214,7 +215,9 @@ if(NOT COMMAND rosbuild_find_ros_package) ## catkin
           set(catkin_INCLUDE_DIRS ${_catkin_INCLUDE_DIRS})
         endif()
       endif()
-      set(need_compile TRUE)
+      if(NOT ${_pkg}_FOUND)
+	set(need_compile FALSE)
+      endif()
       string(REPLACE ":" ";" _cmake_prefix_path $ENV{CMAKE_PREFIX_PATH})
       foreach(_path ${_cmake_prefix_path})
         if(EXISTS ${_path}/share/roseus/ros/${_pkg})


### PR DESCRIPTION
this fill fix compile error only for groovy/deb https://travis-ci.org/jsk-ros-pkg/jsk_recognition/jobs/28691206
