### PR TITLE
remove xfont-server, due to https://github.com/ros/rosdistro/issues/5163

### DIFF
--- a/euslisp/package.xml
+++ b/euslisp/package.xml
@@ -26,7 +26,6 @@
   <build_depend>mk</build_depend>
   <build_depend>xfonts-100dpi</build_depend>
   <build_depend>xfonts-75dpi</build_depend>
-  <build_depend>xfont-server</build_depend>
 
   <run_depend>rostest</run_depend>
   <run_depend>opengl</run_depend>
@@ -37,7 +36,6 @@
   <run_depend>libpq-dev</run_depend>
   <run_depend>xfonts-100dpi</run_depend>
   <run_depend>xfonts-75dpi</run_depend>
-  <run_depend>xfont-server</run_depend>
 
   <export>
     <cpp cflags="-I${prefix}/eus/include"/>


### PR DESCRIPTION
I still not sure if we really need xfs, at least when compile on rosbuild server we do not need xfs, since that build is done without xserver.

When we install euslisp on local machine, we need to restart xfs to activate them, so we still not sure what is the correct way of depending on font server...
