### PR TITLE
use ORIGIN to set rpath

### DIFF
--- a/euslisp/catkin.cmake
+++ b/euslisp/catkin.cmake
@@ -70,7 +70,7 @@ foreach(executable ${executables})
       file(RPATH_CHANGE
            FILE      \"\$ENV{DESTDIR}/\${CMAKE_INSTALL_PREFIX}/${EUSDIR}/${ARCHDIR}/bin/${filename}\"
            OLD_RPATH ${rpath}
-           NEW_RPATH \"\${CMAKE_INSTALL_PREFIX}/${EUSDIR}/${ARCHDIR}/lib\")
+           NEW_RPATH \"$ORIGIN/../lib\")
     endif()")
 endforeach()
 


### PR DESCRIPTION
this is work around for https://github.com/jsk-ros-pkg/jsk_roseus/issues/145, 
due to limitacion of chrpath whcih could not change RPATH to longer path, so
I used $ORIGIN and relative path to specify lib locaitons
