### PR TITLE
add logger and level key param to ros::roseus

### DIFF
--- a/roseus/euslisp/roseus.l
+++ b/roseus/euslisp/roseus.l
@@ -38,6 +38,8 @@
 
 (defun ros::roseus (name &key
                     (anonymous t)
+                    (logger "ros.roseus")
+                    (level ros::*rosinfo*)
                     (args lisp::*eustop-argument*))
   ;; (pprint (list 'roseus_args args))
   (let ((option (if anonymous (list ros::*anonymous-name*) (list))))
@@ -50,6 +52,7 @@
           (setf (elt lisp::*eustop-argument* i)
                 (format nil "(warning-message 1 \"ignore ~a~%\")"
                         (elt lisp::*eustop-argument* i)))))
+      (ros::set-logger-level logger level)
       )))
 
 (setq ros::*compile-message* nil)

--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -130,7 +130,7 @@ static bool s_bInstalled = false;
 #define s_mapServiced s_staticdata.mapServiced
 #define s_mapHandle s_staticdata.mapHandle
 
-pointer K_ROSEUS_MD5SUM,K_ROSEUS_DATATYPE,K_ROSEUS_DEFINITION,K_ROSEUS_SERIALIZATION_LENGTH,K_ROSEUS_SERIALIZE,K_ROSEUS_DESERIALIZE,K_ROSEUS_INIT,K_ROSEUS_GET,K_ROSEUS_REQUEST,K_ROSEUS_RESPONSE,K_ROSEUS_GROUPNAME,QANON,QNOOUT,QREPOVERSION;
+pointer K_ROSEUS_MD5SUM,K_ROSEUS_DATATYPE,K_ROSEUS_DEFINITION,K_ROSEUS_SERIALIZATION_LENGTH,K_ROSEUS_SERIALIZE,K_ROSEUS_DESERIALIZE,K_ROSEUS_INIT,K_ROSEUS_GET,K_ROSEUS_REQUEST,K_ROSEUS_RESPONSE,K_ROSEUS_GROUPNAME,QANON,QNOOUT,QREPOVERSION,QROSDEBUG,QROSINFO,QROSWARN,QROSERROR,QROSFATAL;
 extern pointer LAMCLOSURE;
 
 /***********************************************************
@@ -1456,6 +1456,11 @@ pointer ___roseus(register context *ctx, int n, pointer *argv, pointer env)
 
   QANON=defvar(ctx,"*ANONYMOUS-NAME*",makeint(ros::init_options::AnonymousName),rospkg);
   QNOOUT=defvar(ctx,"*NO-ROSOUT*",makeint(ros::init_options::NoRosout),rospkg);
+  QROSDEBUG=defvar(ctx,"*ROSDEBUG*",makeint(1),rospkg);
+  QROSINFO=defvar(ctx,"*ROSINFO*",makeint(2),rospkg);
+  QROSWARN=defvar(ctx,"*ROSWARN*",makeint(3),rospkg);
+  QROSERROR=defvar(ctx,"*ROSERROR*",makeint(4),rospkg);
+  QROSFATAL=defvar(ctx,"*ROSFATAL*",makeint(5),rospkg);
   defun(ctx,"SPIN",argv[0],(pointer (*)())ROSEUS_SPIN);
   defun(ctx,"SPIN-ONCE",argv[0],(pointer (*)())ROSEUS_SPINONCE);
   defun(ctx,"TIME-NOW-RAW",argv[0],(pointer (*)())ROSEUS_TIME_NOW);


### PR DESCRIPTION
Add logger and level parameter

I wanted to use ros::info but when I use ros::error and ros::warn , it failed, so I use like ros::roserror

please close jsk-ros-pkg/jsk_common#106

We can ues as below

```
1.irteusgl$ 
nil
1.irteusgl$ ros::roseus "test" :anonymous nil :logger "ros" :level ros::rosdebug
t
2.irteusgl$ [DEBUG] [1417849671.017228521]: Accepted connection on socket [7], new socket [11]
[DEBUG] [1417849671.017362039]: Adding tcp socket [11] to pollset
[DEBUG] [1417849671.017397779]: TCPROS received a connection from [127.0.0.1:53764]
[DEBUG] [1417849671.020432395]: Connection: Creating TransportSubscriberLink for topic [/rosout] connected to [callerid=[/rosout] address=[TCPROS connection to [127.0.0.1:53764 on socket 11]]]
```
