### PR TITLE
[geneus] Fix manifest order by using rospack depends rather than rospack_depends script

### DIFF
--- a/geneus/scripts/genmsg-main-eus.l
+++ b/geneus/scripts/genmsg-main-eus.l
@@ -725,7 +725,7 @@
         (setq dir (string-right-trim "manifest.l" target-file)
               target-file "manifest.l")
       (setq dir (format nil "~A/roseus/~A/~A" (ros::ros-home-dir) (unix:getenv "ROS_DISTRO") pkg)))
-    (setq strm (piped-fork (format nil "~A/scripts/rospack_depends ~A" *geneus-dir* pkg)))
+    (setq strm (piped-fork (format nil "rospack depends ~A" pkg)))
     (while (setq l (read-line strm nil))
       (push l depend-pkgs))
     (close strm)


### PR DESCRIPTION
Should fix this
https://github.com/jsk-ros-pkg/jsk_roseus/issues/187
