### PR TITLE
[euslisp] fix syntax of cmake of euslisp.

### DIFF
--- a/euslisp/catkin.cmake
+++ b/euslisp/catkin.cmake
@@ -7,9 +7,9 @@ find_package(catkin REQUIRED COMPONENTS rostest)
 # build euslisp
 execute_process(COMMAND cmake -E chdir ${PROJECT_SOURCE_DIR} make -f Makefile.eus
                 RESULT_VARIABLE _make_failed)
-if (_make_failed)
+if (NOT ${_make_failed} EQUAL 0)
   message(FATAL_ERROR "Build of euslisp failed")
-endif(_make_failed)
+endif(NOT ${_make_failed} EQUAL 0)
 
 #check_for_display(disp)
 #if(disp)


### PR DESCRIPTION
Result variable of execute_process will be defined always, we need to
check the value of the variable