### PR TITLE
[roseus] Use catkin_find instead of rospack find to use vanilla euslisp

### DIFF
--- a/roseus/bin/roseus
+++ b/roseus/bin/roseus
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-EUSLISP_DIR=`rospack find euslisp`
+EUSLISP_DIR=`catkin_find --libexec --share euslisp`
 EUSLISP_EXE=`find -L $EUSLISP_DIR -type f -name irteusgl`
 ROSEUS_DIR=`rospack find roseus`
 ARG_STR=("(pushnew \"${ROSEUS_DIR}/euslisp/\" *load-path* :test #'equal)" \


### PR DESCRIPTION
Need to use catkin_find because now euslisp is cannot found by rospack