### PR TITLE
add load-ros-manifest packages with dependencies option for downward compatibility

### DIFF
--- a/roseus/euslisp/roseus.l
+++ b/roseus/euslisp/roseus.l
@@ -180,7 +180,7 @@
 (defun ros::resolve-ros-path (fname)
   (let* ((urlname (url-pathname fname))
 	 (package-name (send urlname :host))
-	 (path-name (namestring urlname))
+	 (path-name (string-left-trim "/" (namestring urlname)))
 	 (package-path (ros::rospack-find package-name)))
     (when ros::*compile-message*
       (let* ((fname (pathname-name path-name))
@@ -330,13 +330,30 @@ always the rank of list is 2"
 	(load-org-for-ros manifest)
       (ros::ros-error "Could not find ~A~%try rosrun roseus generate-all-msg-srv.sh ~A" manifest pkg))))
 
-(defun ros::load-ros-package (pkg)
-  (unless (find-package (string-upcase pkg))
-    (make-package (string-upcase pkg)))
-  (when (probe-file (format nil "~A/msg" (ros::find-load-msg-path pkg)))
-    (ros::roseus-add-msgs pkg))
-  (when (probe-file (format nil "~A/srv" (ros::find-load-msg-path pkg)))
-    (ros::roseus-add-srvs pkg)))
+(defun ros::load-ros-package (pkg-name &key (with-deps nil))
+  (let ((pkgs (list pkg-name)))
+    (when with-deps
+      (push (ros::find-ros-build-depend-packages pkg-name) pkgs))
+    (dolist (pkg (flatten pkgs))
+      (unless (find-package (string-upcase pkg))
+        (make-package (string-upcase pkg)))
+      (when (probe-file (format nil "~A/msg" (ros::find-load-msg-path pkg)))
+        (ros::roseus-add-msgs pkg))
+      (when (probe-file (format nil "~A/srv" (ros::find-load-msg-path pkg)))
+        (ros::roseus-add-srvs pkg)))))
+
+(defun ros::find-ros-build-depend-packages (pkg)
+  (let ((os
+         (piped-fork (format nil "~A ~A"
+                             (ros::resolve-ros-path "package://roseus/scripts/find_build_depend_packages.py")
+                             pkg)))
+        s
+        lst)
+    (while t
+      (setq s (read-line os nil nil))
+      (if (null s)
+          (return-from ros::find-ros-build-depend-packages (nreverse lst))
+        (push s lst)))))
 
 (setq sys::*exit-hook* 'ros::exit)
 

--- a/roseus/euslisp/roseus.l
+++ b/roseus/euslisp/roseus.l
@@ -324,23 +324,23 @@ always the rank of list is 2"
     (ros::ros-error "Could not find roseus messages for ~A under ~A~%try rosrun roseus generate-all-msg-srv.sh ~A" pkg dirs pkg)
     nil))
 
-(defun ros::load-ros-manifest (pkg)
-  (let ((manifest (format nil "~A/manifest.l" (ros::find-load-msg-path pkg))))
-    (if (probe-file manifest)
-	(load-org-for-ros manifest)
-      (ros::ros-error "Could not find ~A~%try rosrun roseus generate-all-msg-srv.sh ~A" manifest pkg))))
-
-(defun ros::load-ros-package (pkg-name &key (with-deps nil))
+(defun ros::load-ros-manifest (pkg-name &key (with-deps t))
   (let ((pkgs (list pkg-name)))
     (when with-deps
       (push (ros::find-ros-build-depend-packages pkg-name) pkgs))
     (dolist (pkg (flatten pkgs))
-      (unless (find-package (string-upcase pkg))
-        (make-package (string-upcase pkg)))
-      (when (probe-file (format nil "~A/msg" (ros::find-load-msg-path pkg)))
-        (ros::roseus-add-msgs pkg))
-      (when (probe-file (format nil "~A/srv" (ros::find-load-msg-path pkg)))
-        (ros::roseus-add-srvs pkg)))))
+      (let ((manifest (format nil "~A/manifest.l" (ros::find-load-msg-path pkg))))
+        (if (probe-file manifest)
+            (load-org-for-ros manifest)
+          (ros::ros-error "Could not find ~A~%try rosrun roseus generate-all-msg-srv.sh ~A" manifest pkg))))))
+
+(defun ros::load-ros-package (pkg)
+  (unless (find-package (string-upcase pkg))
+    (make-package (string-upcase pkg)))
+  (when (probe-file (format nil "~A/msg" (ros::find-load-msg-path pkg)))
+    (ros::roseus-add-msgs pkg))
+  (when (probe-file (format nil "~A/srv" (ros::find-load-msg-path pkg)))
+    (ros::roseus-add-srvs pkg)))))
 
 (defun ros::find-ros-build-depend-packages (pkg)
   (let ((os

--- a/roseus/scripts/find_build_depend_packages.py
+++ b/roseus/scripts/find_build_depend_packages.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+import os
+import sys
+from catkin_pkg.packages import find_packages
+from catkin_pkg.topological_order import topological_order
+
+
+def main(pkg_name=sys.argv[1]):
+    base_path_str = os.getenv('CMAKE_PREFIX_PATH', None)
+    if base_path_str is None:
+        print "Invalid CMAKE_PREFIX_PATH!"
+    base_paths = base_path_str.replace('/devel','').replace('/install','').split(':')
+    for base_path in base_paths:
+        res = topological_order(base_paths[0], pkg_name)
+        if res:
+            pkg = res[0][1]
+            print os.linesep.join([dep.name for dep in pkg.build_depends])
+            return
+
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is discussed at https://github.com/jsk-ros-pkg/jsk_recognition/issues/701
related with https://github.com/jsk-ros-pkg/jsk_smart_apps/issues/45

Since recent change on `euslisp/geneus`, only the packages that are listed as `generate_messages` at CMakeLists.txt are loaded by `(ros::load-ros-manifest pkg)`.
To generating all messages of `build_depends` packages makes build time so long, so I suggest to find dependent packages and load them on runtime.
