### PR TITLE
do not use too simple variable name

### DIFF
--- a/roseus/euslisp/roseus-utils.l
+++ b/roseus/euslisp/roseus-utils.l
@@ -1073,8 +1073,8 @@
 with the same timestamp"
     (let ((candidates
            (mapcar #'(lambda (buffer)
-                       (find-if #'(lambda (x)
-                                    (let ((diff (ros::time- (send x :header :stamp) stamp)))
+                       (find-if #'(lambda (msg)
+                                    (let ((diff (ros::time- (send msg :header :stamp) stamp)))
                                       (= (send diff :to-sec) 0)))
                                 buffer))
                    (mapcar #'cdr buffers))))


### PR DESCRIPTION
do not use too simple variable name, because error will occur while importing simple name later.