### PR TITLE
change find_pkg order

### DIFF
--- a/roseus_smach/CMakeLists.txt
+++ b/roseus_smach/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(roseus_smach)
 
-find_package(catkin REQUIRED COMPONENTS euslisp roseus smach smach_ros smach_msgs)
+find_package(catkin REQUIRED COMPONENTS euslisp smach smach_ros smach_msgs roseus)
 
 catkin_package(
 #    DEPENDS 


### PR DESCRIPTION
```
[ERROR] [1426480033.555773568]: Could not find roseus messages for smach_msgs under (/home/jskuser/ros/hydro/devel/share/roseus/ros /home/jskuser/ros/hydro_parent/devel/share/roseus/ros /opt/ros/hydro/share/roseus/ros)
try rosrun roseus generate-all-msg-srv.sh smach_msgs
```
このようなエラーが出たので，find_packageの順番を変えました．