### PR TITLE
[roseus_smach] add tests for roseus smach

### DIFF
--- a/roseus_smach/CMakeLists.txt
+++ b/roseus_smach/CMakeLists.txt
@@ -25,3 +25,4 @@ install(DIRECTORY sample src test
 
 add_rostest(test/test-samples.launch)
 add_rostest(test/test_async_join_state_machine_actionlib.launch)
+add_rostest(test/test_parallel_state_machine_sample.launch)

--- a/roseus_smach/CMakeLists.txt
+++ b/roseus_smach/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(roseus_smach)
 
-find_package(catkin REQUIRED COMPONENTS euslisp std_msgs actionlib smach smach_ros smach_msgs message_generation roseus)
+find_package(catkin REQUIRED COMPONENTS euslisp rostest std_msgs actionlib smach smach_ros smach_msgs message_generation roseus)
 
 add_action_files(
   DIRECTORY action
@@ -22,3 +22,5 @@ catkin_package(
 install(DIRECTORY sample src test
         DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
         USE_SOURCE_PERMISSIONS)
+
+add_rostest(test/test-samples.launch)

--- a/roseus_smach/CMakeLists.txt
+++ b/roseus_smach/CMakeLists.txt
@@ -24,3 +24,4 @@ install(DIRECTORY sample src test
         USE_SOURCE_PERMISSIONS)
 
 add_rostest(test/test-samples.launch)
+add_rostest(test/test_async_join_state_machine_actionlib.launch)

--- a/roseus_smach/CMakeLists.txt
+++ b/roseus_smach/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(roseus_smach)
 
-find_package(catkin REQUIRED COMPONENTS euslisp std_msgs actionlib roseus smach smach_ros smach_msgs message_generation)
+find_package(catkin REQUIRED COMPONENTS euslisp std_msgs actionlib smach smach_ros smach_msgs message_generation roseus)
 
 add_action_files(
   DIRECTORY action

--- a/roseus_smach/package.xml
+++ b/roseus_smach/package.xml
@@ -21,6 +21,7 @@
 
   <build_depend>euslisp</build_depend>
   <build_depend>roseus</build_depend>
+  <build_depend>rostest</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>actionlib</build_depend>
   <build_depend>smach</build_depend>
@@ -32,6 +33,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>roseus</run_depend>
+  <run_depend>rostest</run_depend>
   <run_depend>smach</run_depend>
   <run_depend>smach_ros</run_depend>
   <run_depend>smach_msgs</run_depend>

--- a/roseus_smach/test/test-parallel-state-machine.l
+++ b/roseus_smach/test/test-parallel-state-machine.l
@@ -1,0 +1,21 @@
+;; test-parallel-state-machine.l
+;; Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+
+(require :unittest "lib/llib/unittest.l")
+(require :state-machine-utils "package://roseus_smach/src/state-machine-utils.l")
+(load "package://roseus_smach/sample/parallel-state-machine-sample.l")
+
+(ros::roseus "test_parallel_state_machine")
+
+(init-unit-test)
+
+(make-sample-parallel-state-machine)
+
+(deftest test-parallel-state-machine
+  (assert (eq (send (smach-exec *sm*) :name) :success)
+          "test parallel state machine sample"))
+
+(run-all-tests)
+
+(exit)
+

--- a/roseus_smach/test/test-samples.l
+++ b/roseus_smach/test/test-samples.l
@@ -6,14 +6,17 @@
 
 (init-unit-test)
 
-(deftest test-smach-sample
+(deftest test-smach-sample-simple
   (assert (eq (send (smach-exec-simple) :name) :outcome4)
-	  "simple smach sample")
+	  "simple smach sample"))
+
+(deftest test-smach-sample-nested
   (assert (eq (send (smach-exec-nested) :name) :outcome5)
-	  "nested smach sample")
+	  "nested smach sample"))
+
+(deftest test-smach-sample-userdata
   (assert (eq (send (smach-exec-userdata) :name) :outcome4)
-	  "sample of smach with userdata")
-  )
+	  "sample of smach with userdata"))
 
 (run-all-tests)
 

--- a/roseus_smach/test/test_parallel_state_machine_sample.launch
+++ b/roseus_smach/test/test_parallel_state_machine_sample.launch
@@ -1,0 +1,4 @@
+<launch>
+  <test test-name="test_parallel_state_machine_samples" pkg="roseus" type="roseus"
+        args="$(find roseus_smach)/test/test-parallel-state-machine.l" />
+</launch>


### PR DESCRIPTION
add tests for
- existing samples for basic SMACH features ( simple, nested and userdata)
- parallel executive state machine
- async join-able state machine

and add them to `CMakeLists.txt` as `rostest`

This is another PR of https://github.com/jsk-ros-pkg/jsk_roseus/pull/293.