### PR TITLE
Add test for concurrent state machine

### DIFF
--- a/roseus_smach/CMakeLists.txt
+++ b/roseus_smach/CMakeLists.txt
@@ -26,3 +26,4 @@ install(DIRECTORY sample src test
 add_rostest(test/test-samples.launch)
 add_rostest(test/test_async_join_state_machine_actionlib.launch)
 add_rostest(test/test_parallel_state_machine_sample.launch)
+add_rostest(test/test_concurrent_state_machine_sample.launch)

--- a/roseus_smach/sample/concurrent-state-machine-sample.l
+++ b/roseus_smach/sample/concurrent-state-machine-sample.l
@@ -1,0 +1,92 @@
+#!/usr/bin/env irteusgl
+;; paralell-state-machine-sample.l
+;; Author: Furushchev <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+
+(require :state-machine "package://roseus_smach/src/state-machine.l")
+(require :state-machine-ros "package://roseus_smach/src/state-machine-ros.l")
+(require :state-mcahine-utils "package://roseus_smach/src/state-machine-utils.l")
+
+(defclass washing-machine
+ :super propertied-object
+ :slots (door soap cloth))
+
+(defmethod washing-machine
+  (:init ()
+   (setq door :close))
+  (:open-door ()
+   (warning-message 2 ";; open door~%")
+   (setq door :open)
+   t)
+  (:put-cloth (clothes)
+   (warning-message 2 ";; put ~A clothes~%" (length clothes))
+   (setq cloth clothes)
+   t)
+  (:put-soap ()
+   (warning-message 2 ";; put soap~%")
+   (setq soap t)
+   t)
+  (:hoge ()
+   (warning-message 2 ";; hoge~%")
+   t)
+  (:hoo ()
+   (warning-message 2 ";; hoo~%")
+   t)
+  (:fuga ()
+   (warning-message 2 ";; fuga~%")
+   t)
+  (:close-door ()
+   (warning-message 2 ";; close door~%")
+   (setq door :close)
+   t)
+  (:press-button ()
+   (warning-message 2 ";; press button~%")
+   (cond
+     ((eq door :open)
+      (warning-message 1 "you forgot close door!!~%"))
+     ((null soap)
+      (warning-message 1 "you forgot to use soap!!"))
+     ((null cloth)
+      (warning-message 1 "no cloth in washing machine!!~%"))
+     (t
+      (warning-message 4 "To keep your cloth clean is to keep your mind clean.")
+      (return-from :press-button t)))
+   (error)))
+
+(defun make-sample-concurrent-state-machine ()
+  (setq *wash* (instance washing-machine :init))
+  (setq *sm*
+        (make-state-machine
+         '((:open-door -> (:put-soap :put-cloth))
+           (:put-soap -> :hoo)
+           (:hoo -> :close-door)
+           (:put-cloth ->  :hoge)
+           (:hoge -> :fuga)
+           (:fuga -> :close-door)
+           (:close-door -> :press-button)
+           (:press-button -> :success))
+         '((:open-door #'(lambda (&rest args) (send *wash* :open-door)))
+           (:put-cloth #'(lambda (&rest args) (send *wash* :put-cloth '(:towel :t-shirt))))
+           (:put-soap  #'(lambda (&rest args) (send *wash* :put-soap)))
+           (:hoge  #'(lambda (&rest args) (send *wash* :hoge)))
+           (:hoo  #'(lambda (&rest args) (send *wash* :hoo)))
+           (:fuga  #'(lambda (&rest args) (send *wash* :fuga)))
+           (:press-button #'(lambda (&rest args) (send *wash* :press-button)))
+           (:close-door #'(lambda (&rest args) (send *wash* :close-door))))
+         '(:open-door)
+         '(:success))))
+
+(defun init ()
+  (ros::roseus "sample_parallel_state_machine")
+  (make-sample-parallel-state-machine)
+  (ros::ros-info "created state machine ~A" *sm*))
+
+(warning-message 3 ";; (init)~%")
+
+(defun demo ()
+  (when (or (not (boundp '*sm*)) (not (boundp '*wash*)))
+    (init))
+  (exec-smach-with-spin *sm*))
+
+(warning-message 3 ";; (demo)~%")
+
+(provide :paralell-state-machine-sample)

--- a/roseus_smach/test/test-concurrent-state-machine.l
+++ b/roseus_smach/test/test-concurrent-state-machine.l
@@ -1,0 +1,20 @@
+;; test-parallel-state-machine.l
+;; Author: Hitoshi Kamada <h-kamada@jsk.imi.i.u-tokyo.ac.jp>
+
+(require :unittest "lib/llib/unittest.l")
+(require :state-machine-utils "package://roseus_smach/src/state-machine-utils.l")
+(load "package://roseus_smach/sample/concurrent-state-machine-sample.l")
+
+(ros::roseus "test_concurrent_state_machine")
+
+(init-unit-test)
+
+(make-sample-concurrent-state-machine)
+
+(deftest test-concurrent-state-machine
+  (assert (eq (send (smach-exec *sm*) :name) :success)
+          "test concurrent state machine sample"))
+
+(run-all-tests)
+
+(exit)

--- a/roseus_smach/test/test_concurrent_state_machine_sample.launch
+++ b/roseus_smach/test/test_concurrent_state_machine_sample.launch
@@ -1,0 +1,4 @@
+<launch>
+  <test test-name="test_concurrent_state_machine_samples" pkg="roseus" type="roseus"
+        args="$(find roseus_smach)/test/test-concurrent-state-machine.l" />
+</launch>


### PR DESCRIPTION
##### add test for concurrent-state-machine
concurrent-state-machine is similar to parallel-state-machine (by @furushchev ), but several points differ.

* parallel-state-machine (by @furushchev )

    ```
A -> B  -> D 
      -> C  ->
    ```

    D is join node. So, behavior is like this. Stay at A. After A ends, switch to B and C. After that, immediately switch to D. The virtual node checking whether B or C is executed is D. After B and C's func end, D ends. 

* concurrent-state-machine (mine)

    ```
A -> B  -> D
      -> C  ->
    ```

    D is not join node. Normal node. Join node isn't needed. So, behavior is like this. Stay at A. After A ends, switch to B and C. When B and C end, switch to D. 

    concurrent-state-machine doesn't need join node. So, following transition is easy to write.

    ```
A -> B -> D -------> G
      |                ↑
      -> C -> E -> F ->
    ```

    