### PR TITLE
roseus.cpp: add ros::create-timer function

### DIFF
--- a/roseus/CMakeLists.txt
+++ b/roseus/CMakeLists.txt
@@ -105,6 +105,7 @@ add_rostest(test/test-disconnect.test)
 add_rostest(test/test-multi-queue.test)
 add_rostest(test/test-parameter.test)
 add_rostest(test/test-anonymous.test)
+add_rostest(test/test-timer.test)
 add_rostest(test/test-genmsg.catkin.test)
 # this will not ok on running from run_tests, may be running test within launch file may not good.
 #add_rostest(test/test-genmsg-oneworkspace.catkin.launch) # use launch not to run on travis/catkin

--- a/roseus/euslisp/roseus.l
+++ b/roseus/euslisp/roseus.l
@@ -127,6 +127,30 @@
 (defun ros::time<= (a b)
   (not (ros::time> a b)))
 
+;;
+(defclass timer-event
+  :super propertied-object
+  :slots (last-expected last-real current-expected current-real last-duration))
+(defmethod timer-event
+  (:init ()
+    (setq last-expected (ros::time)
+          last-real (ros::time)
+          current-expected (ros::time)
+          current-real (ros::time)
+          last-duration (ros::time))
+    self)
+  (:prin1 (&optional (strm t) &rest msgs)
+	    (send-super :prin1 strm
+			(format nil "last-expected ~7,3f, last-real ~7,3f, current-expected ~7,3f, current-real ~7,3f, last-duration ~7,3f" (send last-expected :to-sec) (send last-real :to-sec) (send current-expected :to-sec) (send current-real :to-sec) (send last-duration :to-sec))))
+  (:last-expected (&rest args) (user::forward-message-to last-expected args))
+  (:last-real (&rest args) (user::forward-message-to last-real args))
+  (:current-expected (&rest args) (user::forward-message-to current-expected args))
+  (:current-real (&rest args) (user::forward-message-to current-real args))
+  (:last-duration (&rest args) (user::forward-message-to last-duration args))
+  )
+
+
+;;
 
 
 (defun ros::ros-home-dir ()

--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -117,6 +117,7 @@ public:
   map<string, boost::shared_ptr<Publisher> > mapAdvertised; ///< advertised topics
   map<string, boost::shared_ptr<Subscriber> > mapSubscribed; ///< subscribed topics
   map<string, boost::shared_ptr<ServiceServer> > mapServiced; ///< subscribed topics
+  map<string, Timer > mapTimered; ///< subscribed timers
 
   map<string, boost::shared_ptr<NodeHandle> > mapHandle; ///< for grouping nodehandle
 };
@@ -128,9 +129,10 @@ static bool s_bInstalled = false;
 #define s_mapAdvertised s_staticdata.mapAdvertised
 #define s_mapSubscribed s_staticdata.mapSubscribed
 #define s_mapServiced s_staticdata.mapServiced
+#define s_mapTimered s_staticdata.mapTimered
 #define s_mapHandle s_staticdata.mapHandle
 
-pointer K_ROSEUS_MD5SUM,K_ROSEUS_DATATYPE,K_ROSEUS_DEFINITION,K_ROSEUS_SERIALIZATION_LENGTH,K_ROSEUS_SERIALIZE,K_ROSEUS_DESERIALIZE,K_ROSEUS_INIT,K_ROSEUS_GET,K_ROSEUS_REQUEST,K_ROSEUS_RESPONSE,K_ROSEUS_GROUPNAME,QANON,QNOOUT,QREPOVERSION,QROSDEBUG,QROSINFO,QROSWARN,QROSERROR,QROSFATAL;
+pointer K_ROSEUS_MD5SUM,K_ROSEUS_DATATYPE,K_ROSEUS_DEFINITION,K_ROSEUS_SERIALIZATION_LENGTH,K_ROSEUS_SERIALIZE,K_ROSEUS_DESERIALIZE,K_ROSEUS_INIT,K_ROSEUS_GET,K_ROSEUS_REQUEST,K_ROSEUS_RESPONSE,K_ROSEUS_GROUPNAME,K_ROSEUS_ONESHOT,K_ROSEUS_LAST_EXPECTED,K_ROSEUS_LAST_REAL,K_ROSEUS_CURRENT_EXPECTED,K_ROSEUS_CURRENT_REAL,K_ROSEUS_LAST_DURATION,K_ROSEUS_SEC,K_ROSEUS_NSEC,QANON,QNOOUT,QREPOVERSION,QROSDEBUG,QROSINFO,QROSWARN,QROSERROR,QROSFATAL;
 extern pointer LAMCLOSURE;
 
 /***********************************************************
@@ -542,10 +544,19 @@ pointer ROSEUS(register context *ctx,int n,pointer *argv)
   K_ROSEUS_REQUEST  = defkeyword(ctx,"REQUEST");
   K_ROSEUS_RESPONSE = defkeyword(ctx,"RESPONSE");
   K_ROSEUS_GROUPNAME = defkeyword(ctx,"GROUPNAME");
+  K_ROSEUS_ONESHOT = defkeyword(ctx,"ONESHOT");
+  K_ROSEUS_LAST_EXPECTED = defkeyword(ctx,"LAST-EXPECTED");
+  K_ROSEUS_LAST_REAL = defkeyword(ctx,"LAST-REAL");
+  K_ROSEUS_CURRENT_EXPECTED = defkeyword(ctx,"CURRENT-EXPECTED");
+  K_ROSEUS_CURRENT_REAL = defkeyword(ctx,"CURRENT-REAL");
+  K_ROSEUS_LAST_DURATION = defkeyword(ctx,"LAST-DURATION");
+  K_ROSEUS_SEC = defkeyword(ctx,"SEC");
+  K_ROSEUS_NSEC = defkeyword(ctx,"NSEC");
 
   s_mapAdvertised.clear();
   s_mapSubscribed.clear();
   s_mapServiced.clear();
+  s_mapTimered.clear();
   s_mapHandle.clear();
   
   /*
@@ -728,6 +739,7 @@ pointer ROSEUS_EXIT(register context *ctx,int n,pointer *argv)
     s_mapAdvertised.clear();
     s_mapSubscribed.clear();
     s_mapServiced.clear();
+    s_mapTimered.clear();
     s_mapHandle.clear();
     ros::shutdown();
   }
@@ -1519,6 +1531,115 @@ pointer ROSEUS_GET_TOPICS(register context *ctx,int n,pointer *argv)
   return ccdr(first);
 }
 
+class TimerFunction
+{
+  pointer _scb, _args;
+public:
+  TimerFunction(pointer scb, pointer args) : _scb(scb), _args(args) {
+    context *ctx = current_ctx;
+    //ROS_WARN("func");prinx(ctx,scb,ERROUT);flushstream(ERROUT);terpri(ERROUT);
+    //ROS_WARN("argc");prinx(ctx,args,ERROUT);flushstream(ERROUT);terpri(ERROUT);
+  }
+  void operator()(const ros::TimerEvent& event)
+  {
+    mutex_trylock(&mark_lock);
+    context *ctx = current_ctx;
+    numunion nu;
+    pointer argp=_args;
+    int argc=0;
+
+    pointer clsptr = NIL;
+    for(int i=0; i<nextcix;i++) {
+      if(!memcmp(classtab[i].def->c.cls.name->c.sym.pname->c.str.chars,(char *)"TIMER-EVENT",11)) {
+        clsptr = classtab[i].def;
+      }
+    }
+    if ( ! ( issymbol(_scb) || piscode(_scb) || ccar(_scb)==LAMCLOSURE ) ) {
+      ROS_ERROR("%s : can't find callback function", __PRETTY_FUNCTION__);
+    }
+
+    pointer tevent = makeobject(clsptr);
+    csend(ctx,tevent,K_ROSEUS_INIT,0);
+    csend(ctx,tevent,K_ROSEUS_LAST_EXPECTED,2,K_ROSEUS_SEC,makeint(event.last_expected.sec));
+    csend(ctx,tevent,K_ROSEUS_LAST_EXPECTED,2,K_ROSEUS_NSEC,makeint(event.last_expected.nsec));
+    csend(ctx,tevent,K_ROSEUS_LAST_REAL,2,K_ROSEUS_SEC,makeint(event.last_real.sec));
+    csend(ctx,tevent,K_ROSEUS_LAST_REAL,2,K_ROSEUS_NSEC,makeint(event.last_real.nsec));
+    csend(ctx,tevent,K_ROSEUS_CURRENT_EXPECTED,2,K_ROSEUS_SEC,makeint(event.current_expected.sec));
+    csend(ctx,tevent,K_ROSEUS_CURRENT_EXPECTED,2,K_ROSEUS_NSEC,makeint(event.current_expected.nsec));
+    csend(ctx,tevent,K_ROSEUS_CURRENT_REAL,2,K_ROSEUS_SEC,makeint(event.current_real.sec));
+    csend(ctx,tevent,K_ROSEUS_CURRENT_REAL,2,K_ROSEUS_NSEC,makeint(event.current_real.nsec));
+    csend(ctx,tevent,K_ROSEUS_LAST_DURATION,2,K_ROSEUS_SEC,makeint(event.profile.last_duration.sec));
+    csend(ctx,tevent,K_ROSEUS_LAST_DURATION,2,K_ROSEUS_NSEC,makeint(event.profile.last_duration.nsec));
+
+    while(argp!=NIL){ ckpush(ccar(argp)); argp=ccdr(argp); argc++;}
+    vpush((pointer)(tevent));argc++;
+
+    ufuncall(ctx,(ctx->callfp?ctx->callfp->form:NIL),_scb,(pointer)(ctx->vsp-argc),NULL,argc);
+    while(argc-->0)vpop();
+
+    mutex_unlock(&mark_lock);
+  }
+};
+
+pointer ROSEUS_CREATE_TIMER(register context *ctx,int n,pointer *argv)
+{
+  isInstalledCheck;
+  numunion nu;
+  bool oneshot = false;
+  pointer fncallback, args;
+  NodeHandle *lnode = s_node.get();
+  string fncallname;
+  float period=ckfltval(argv[0]);
+
+  mutex_trylock(&mark_lock);
+  // period callbackfunc args0 ... argsN [ oneshot ]
+  // ;; oneshot ;;
+  if (n > 1 && issymbol(argv[n-2]) && issymbol(argv[n-1])) {
+    if (argv[n-2] == K_ROSEUS_ONESHOT) {
+      if ( argv[n-1] != NIL ) {
+        oneshot = true;
+      }
+      n -= 2;
+    }
+  }
+  // ;; functions ;;
+  if (piscode(argv[1])) { // compiled code
+    fncallback=argv[1];
+    std::ostringstream stringstream;
+    stringstream << reinterpret_cast<long>(argv[2]) << " ";
+    for (int i=3; i<n;i++)
+      stringstream << string((char*)(argv[i]->c.sym.pname->c.str.chars)) << " ";
+    fncallname = stringstream.str();
+  } else if ((ccar(argv[1]))==LAMCLOSURE) { // uncompiled code
+    if ( ccar(ccdr(argv[1])) != NIL ) { // function
+      fncallback=ccar(ccdr(argv[1]));
+      fncallname = string((char*)(fncallback->c.sym.pname->c.str.chars));
+    } else { // lambda function
+      fncallback=argv[1];
+      std::ostringstream stringstream;
+      stringstream << reinterpret_cast<long>(argv[1]);
+      fncallname = stringstream.str();
+    }
+  } else {
+    ROS_ERROR("subscription callback function install error");
+  }
+
+  // ;; arguments ;;
+  args=NIL;
+  for (int i=n-1;i>=2;i--) args=cons(ctx,argv[i],args);
+
+  // avoid gc
+  pointer p=gensym(ctx);
+  setval(ctx,intern(ctx,(char*)(p->c.sym.pname->c.str.chars),strlen((char*)(p->c.sym.pname->c.str.chars)),lisppkg),cons(ctx,fncallback,args));
+
+  // ;; store mapTimered
+  ROS_DEBUG("create timer %s at %f (oneshot=%d)", fncallname.c_str(), period, oneshot);
+  s_mapTimered[fncallname] = lnode->createTimer(ros::Duration(period), TimerFunction(fncallback, args), oneshot);
+
+  mutex_unlock(&mark_lock);
+  return (T);
+}
+
 /************************************************************
  *   __roseus
  ************************************************************/
@@ -1587,6 +1708,8 @@ pointer ___roseus(register context *ctx, int n, pointer *argv, pointer env)
   defun(ctx,"GET-PORT",argv[0],(pointer (*)())ROSEUS_GET_PORT);
   defun(ctx,"GET-URI",argv[0],(pointer (*)())ROSEUS_GET_URI);
   defun(ctx,"GET-TOPICS",argv[0],(pointer (*)())ROSEUS_GET_TOPICS);
+
+  defun(ctx,"CREATE-TIMER",argv[0],(pointer (*)())ROSEUS_CREATE_TIMER);
 
   pointer_update(Spevalof(PACKAGE),p);
 

--- a/roseus/test/test-timer.l
+++ b/roseus/test/test-timer.l
@@ -1,0 +1,55 @@
+#!/usr/bin/env roseus
+
+(setq sys::*gc-hook* #'(lambda (a b) (format *error-output* ";; gc ~A ~A~%" a b)))
+
+;;
+(ros::roseus "test_timer")
+(ros::advertise "chatter1" std_msgs::string 1)
+(ros::advertise "chatter2" std_msgs::string 1)
+(ros::advertise "chatter3" std_msgs::string 1)
+(ros::advertise "chatter4" std_msgs::string 1)
+(ros::advertise "chatter5" std_msgs::string 1)
+
+(defun cb1 (event)
+  (let (msg)
+    (print event)
+    (setq msg (instance std_msgs::string :init))
+    (send msg :data (format nil "hello world ~a" (send (ros::time-now) :sec-nsec)))
+    (ros::publish "chatter1" msg)
+    ))
+(defun cb2 (event)
+  (let (msg)
+    (setq msg (instance std_msgs::string :init))
+    (send msg :data (format nil "hello world ~a" (send (ros::time-now) :sec-nsec)))
+    (ros::publish "chatter2" msg)
+    ))
+(ros::create-timer 0.1 #'cb1)
+(ros::create-timer 0.1 #'cb2)
+
+(ros::create-timer 0.1 #'(lambda (event) 
+                          (let (msg)
+                            (setq msg (instance std_msgs::string :init))
+                            (send msg :data (format nil "hello world ~a" (send (ros::time-now) :sec-nsec)))
+                            (ros::publish "chatter3" msg)
+                            )))
+
+(defclass cb
+  :super propertied-object
+  :slots (topic))
+(defmethod cb
+  (:init (tpc) (setq topic tpc) self)
+  (:call (event)
+   (let (msg)
+     (setq msg (instance std_msgs::string :init))
+     (send msg :data (format nil "hello world ~a" (send (ros::time-now) :sec-nsec)))
+     (ros::publish topic msg)
+     )))
+(setq ccb1 (instance cb :init "chatter4"))
+(setq ccb2 (instance cb :init "chatter5"))
+(ros::create-timer 0.1 #'send ccb1 :call)
+(ros::create-timer 0.1 #'send ccb2 :call)
+(ros::spin)
+
+
+
+

--- a/roseus/test/test-timer.test
+++ b/roseus/test/test-timer.test
@@ -1,0 +1,35 @@
+<launch>
+  <node type="roseus" pkg="roseus" name="test_timer"
+        args="$(find roseus)/test/test-timer.l" output="screen"
+        required="true" />
+
+  <param name="hz_timer1/topic" value="chatter1" />  
+  <param name="hz_timer1/hz" value="10.0" />
+  <param name="hz_timer1/hzerror" value="0.5" />
+  <param name="hz_timer1/test_duration" value="5.0" />
+  <test test-name="test_timer1" pkg="rostest" type="hztest" name="hz_timer1" />
+
+  <param name="hz_timer2/topic" value="chatter1" />  
+  <param name="hz_timer2/hz" value="10.0" />
+  <param name="hz_timer2/hzerror" value="0.5" />
+  <param name="hz_timer2/test_duration" value="5.0" />
+  <test test-name="test_timer2" pkg="rostest" type="hztest" name="hz_timer2" />
+
+  <param name="hz_timer3/topic" value="chatter1" />  
+  <param name="hz_timer3/hz" value="10.0" />
+  <param name="hz_timer3/hzerror" value="0.5" />
+  <param name="hz_timer3/test_duration" value="5.0" />
+  <test test-name="test_timer3" pkg="rostest" type="hztest" name="hz_timer3" />
+
+  <param name="hz_timer4/topic" value="chatter1" />  
+  <param name="hz_timer4/hz" value="10.0" />
+  <param name="hz_timer4/hzerror" value="0.5" />
+  <param name="hz_timer4/test_duration" value="5.0" />
+  <test test-name="test_timer4" pkg="rostest" type="hztest" name="hz_timer4" />
+
+  <param name="hz_timer5/topic" value="chatter1" />  
+  <param name="hz_timer5/hz" value="10.0" />
+  <param name="hz_timer5/hzerror" value="0.5" />
+  <param name="hz_timer5/test_duration" value="5.0" />
+  <test test-name="test_timer5" pkg="rostest" type="hztest" name="hz_timer5" />
+</launch>


### PR DESCRIPTION
based on http://wiki.ros.org/roscpp/Overview/Timers, see #237

currently, proposed API is something like this.

```
(defun cb1 (event)
  (let (msg)
    (setq msg (instance std_msgs::string :init))
    (send msg :data (format nil "hello world ~a" (send (ros::time-now) :sec-nsec)))
    (ros::publish "chatter1" msg)
    ))
(ros::create-timer 0.1 #'cb1)
```

another possibility is
```
(ros::create-timer ros::Timer(0.1) #'cb1)
```

I also did not implement ros::TimerEvent class(http://wiki.ros.org/roscpp/Overview/Timers#Callback_Signature), does it should be class instance? or just to pass 
`(list last_expected last_real current_expected current_real profile.last_duration)` is ok for you?