### PR TITLE
adding build_depends to package.xml is wrong.

### DIFF
--- a/jsk_roseus/package.xml
+++ b/jsk_roseus/package.xml
@@ -24,7 +24,8 @@
 
   <!-- this is not necessary but added to avoid race conding on
        generating .catkin file, see https://github.com/ros/catkin/pull/671 -->
-  <build_depend>roseus</build_depend>
+  <!-- build_depend>roseus</build_depend --> <!-- removed, WARNING: Metapackage "jsk_roseus" should not have other dependencies besides a buildtool_depend on catkin and run_depends.
+ -->
 
   <export>
     <metapackage/>


### PR DESCRIPTION
this will eliminate
```
WARNING: Metapackage "jsk_roseus" should not have other dependencies besides a buildtool_depend on catkin and run_depends.
```