### PR TITLE
[roseus_mongo/euslisp/json/json-decode.l] use keyword for key as default

### DIFF
--- a/roseus_mongo/euslisp/json/json-decode.l
+++ b/roseus_mongo/euslisp/json/json-decode.l
@@ -5,10 +5,7 @@
   (intern (string-upcase str) *keyword-package*))
 
 (defvar *json-parse-object-as* :alist)
-(defvar *json-parse-key-function*
-  (if (eq *json-parse-object-as* :plist)
-      #'string->keyword
-      #'identity))
+(defvar *json-parse-key-function* #'string->keyword)
 
 (unless (find-package "JSON") (make-package "JSON"))
 (in-package "JSON")

--- a/roseus_mongo/test/test-json-decode.l
+++ b/roseus_mongo/test/test-json-decode.l
@@ -68,27 +68,27 @@
 
 (deftest test-json-decode-object
   (assert (equal
-           '(("1" . 2))
+           '((:1 . 2))
            (with-input-from-string (is "{1:2}")
                          (json::parse-object is))))
   (assert (equal
-           '(("1" . "abc"))
+           '((:1 . "abc"))
            (with-input-from-string (is "{1:\"abc\"}")
                          (json::parse-object is))))
   (assert (equal
-           '(("1" . 2) ("2" . t))
+           '((:1 . 2) (:2 . t))
            (with-input-from-string (is "{1:2,  \"2\": true}")
                          (json::parse-object is))))
   (assert (equal
-           '(("1" ("abc" . 2)))
+           '((:1 (:abc . 2)))
            (with-input-from-string (is "{1:{\"abc\":2}}")
                          (json::parse-object is))))
   (assert (equal
-           '(("1" ("abc" 2 t)))
+           '((:1 (:abc 2 t)))
            (with-input-from-string (is "{1:{\"abc\":[2,true]}}")
                          (json::parse-object is))))
   (assert (equal
-           '(("1" (("2" . 3)) (("4" . t))))
+           '((:1 ((:2 . 3)) ((:4 . t))))
            (with-input-from-string (is "{1:[{2:3},{4:true}]}")
                          (json::parse-object is))))
   )


### PR DESCRIPTION
With this change, we can use `assoc` with keyword instead of string (now we don't need `:test #'string=`)