### PR TITLE
Fix resolve

### DIFF
--- a/roseus/euslisp/roseus.l
+++ b/roseus/euslisp/roseus.l
@@ -189,11 +189,11 @@
 	 (package-name (send urlname :host))
 	 (path-name (namestring urlname))
 	 (package-path (ros::rospack-find package-name)))
-    (if (= (elt package-path (1- (length package-path))) #\/) ;; if end with /
+    (if (and package-path (= (elt package-path (1- (length package-path))) #\/)) ;; if end with /
         (setq package-path (subseq package-path 0 (1- (length package-path)))))
-    (if (= (elt path-name 0) #\/) ;; if start with /
+    (if (and path-name (= (elt path-name 0) #\/)) ;; if start with /
         (setq path-name (subseq path-name 1)))
-    (if package-path
+    (if (and package-path path-name)
 	(format nil "~A/~A" package-path path-name)
       (progn (warning-message 1 ";; could not find pacakge [~a]~%" package-name) nil))))
 

--- a/roseus/test/test-roseus.l
+++ b/roseus/test/test-roseus.l
@@ -77,6 +77,11 @@
     ;;
     ))
 
+(deftest resolve-path ()
+  (assert (ros::resolve-ros-path "package://roseus"))
+  (assert (not (ros::resolve-ros-path "package://not_existing_package")))
+  )
+
 (run-all-tests)
 
 (exit)


### PR DESCRIPTION
ros::resolve-ros-path returns when taking non existing package name