### PR TITLE
[roseus_mongo/euslisp/mongo-client.l] fix: function name `insert` -> `insert-msg` for avoiding name collision

### DIFF
--- a/roseus_mongo/euslisp/mongo-client-sample.l
+++ b/roseus_mongo/euslisp/mongo-client-sample.l
@@ -29,10 +29,10 @@
 
 ;; inserting message to database
 (setq msg (instance geometry_msgs::Pose :init))
-(setq document-id (mongo::insert msg))
+(setq document-id (mongo::insert-msg msg))
 
 ;; you can also insert with annotating meta data
-(mongo::insert msg :meta '((:memo . "my awesome pose")))
+(mongo::insert-msg msg :meta '((:memo . "my awesome pose")))
 
 ;; deleting message from database
 (setq success-p (mongo::delete-by-id document-id))

--- a/roseus_mongo/euslisp/mongo-client.l
+++ b/roseus_mongo/euslisp/mongo-client.l
@@ -67,7 +67,7 @@
                       (cons msg (json::parse-from-string meta-raw-string)))))
             (send res :messages) (send res :metas))))
 
-(defun insert (msg &key meta (encoder #'json::encode-alist))
+(defun insert-msg (msg &key meta (encoder #'json::encode-alist))
   (let ((req (instance mongodb_store_msgs::MongoInsertMsgRequest :init))
         res)
     (send req :database user::*mongo-database*)

--- a/roseus_mongo/test/test-mongo-client.l
+++ b/roseus_mongo/test/test-mongo-client.l
@@ -12,7 +12,7 @@
 
   (setq msg (instance geometry_msgs::Pose :init
                       :position (instance geometry_msgs::Point :init :x 1 :y 2 :z 3)))
-  (setq doc-id (mongo::insert msg))
+  (setq doc-id (mongo::insert-msg msg))
   (warn "doc-id: ~A~%" doc-id)
 
   (setq res (mongo::query geometry_msgs::Pose :query '((:_id . ((:$oid . doc-id)))) :single t :msg-only t))
@@ -33,7 +33,7 @@
 
   (dotimes (i 10)
     (send msg :position :x i)
-    (mongo::insert msg))
+    (mongo::insert-msg msg))
 
   (setq res-many (mongo::query geometry_msgs::Pose :sort '((:natural . 1 )) :msg-only t))
   (dotimes (i 10)


### PR DESCRIPTION
This PR fixes https://github.com/euslisp/EusLisp/issues/138