### PR TITLE
.travis.yml: re-enable jade and hydro with released deb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,9 @@ matrix:
 #     - env: ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin   USE_DEB=false
 before_script:
   - set -x
+  - if [ "${INSTALL_SRC}" != "" ] ;then sudo apt-get install python-yaml; rm .travis.rosinstall; for src in $INSTALL_SRC; do name=`basename $src`; python -c "import yaml;print yaml.dump([{'git':{'uri':'$src','local-name':'$name'}}], default_flow_style=False)" >> .travis.rosinstall; done; cat .travis.rosinstall; export USE_DEB=false; fi; # set USE_DEB false to enable .travis.rosinstall
   - if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then openssl aes-256-cbc -K $encrypted_b79fc5843df3_key -iv $encrypted_b79fc5843df3_iv -in .secrets.tar.enc -out .secrets.tar -d; tar -C ~/ -xvf .secrets.tar; export INSTALL_SRC="$INSTALL_SRC $INSTALL_SRC_SECURE"; export TEST_PKGS="$TEST_PKGS $TEST_PKGS_SECURE"; fi
   - export REPOSITORY_NAME=`basename $PWD`
-  - if [ "${INSTALL_SRC}" != "" ] ;then sudo apt-get install python-yaml; rm .travis.rosinstall; for src in $INSTALL_SRC; do name=`basename $src`; python -c "import yaml;print yaml.dump([{'git':{'uri':'$src','local-name':'$name'}}], default_flow_style=False)" >> .travis.rosinstall; done; cat .travis.rosinstall; export USE_DEB=false; fi; # set USE_DEB false to enable .travis.rosinstall
 script:
   - .travis/travis.sh
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,9 @@ env:
     - ROS_DISTRO=jade USE_DEB=source     TEST_PKGS="roseus roseus_smach" NOT_TEST_INSTALL=true
 matrix:
   allow_failures:
-    - env: ROS_DISTRO=hydro  USE_DEB=true       ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - env: ROS_DISTRO=jade USE_DEB=true       TEST_PKGS="roseus roseus_smach" NOT_TEST_INSTALL=true
-    - env: ROS_DISTRO=jade USE_DEB=true       ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu TEST_PKGS="roseus roseus_smach" NOT_TEST_INSTALL=true
+#     - env: ROS_DISTRO=hydro  USE_DEB=true       ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+#     - env: ROS_DISTRO=jade USE_DEB=true       TEST_PKGS="roseus roseus_smach" NOT_TEST_INSTALL=true
+#     - env: ROS_DISTRO=jade USE_DEB=true       ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu TEST_PKGS="roseus roseus_smach" NOT_TEST_INSTALL=true
 #     - env: ROS_DISTRO=hydro  ROSWS=wstool BUILDER=catkin    USE_DEB=false
 #     - env: ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin   USE_DEB=true
 #     - env: ROS_DISTRO=indigo  ROSWS=wstool BUILDER=catkin   USE_DEB=false


### PR DESCRIPTION
https://github.com/jsk-ros-pkg/jsk_roseus/pull/372#issuecomment-141421746

> We can say still jade is too early for us. Should we set jade allow_failures instead of ignoring these error?

Since jade is current "official" release and we already have roseus as "official" client program for jade, I think we have responsibility to keep roseus working on jade. So we should not put jade to allow_failures.

and I expect this would work, if we compare https://travis-ci.org/jsk-ros-pkg/jsk_roseus/jobs/81017815 and https://travis-ci.org/jsk-ros-pkg/jsk_roseus/jobs/81053071, woking version using euslisp, geneus from source, even though that uses USE_DEB=true, so someone broke jsk_travis
