### PR TITLE
[WIP] [roseus] Add topic-listener helper class to write ros program in procedual manner

### DIFF
--- a/roseus/euslisp/roseus-utils.l
+++ b/roseus/euslisp/roseus-utils.l
@@ -1141,6 +1141,27 @@ with the same timestamp"
       ))
   )
 
+(defclass topic-listener
+  :super propertied-object
+  :slots (topic msg-type lockedp value)
+  :documentation "Utility class to write program in procedual manner
+ rather than event-driven manner.")
+
+(defmethod topic-listener
+  (:init (atopic amsg-type)
+    (setq topic atopic)
+    (setq msg-type amsg-type)
+    (ros::subscribe topic amsg-type #'send self :callback))
+  (:callback (msg)
+    (unless lockedp
+      (setq value msg)))
+  (:lock ()
+    (setq lockedp t))
+  (:unlock ()
+    (setq lockedp nil))
+  (:value () value)
+  )
+
 #|
 ;; sample
 (defclass image-caminfo-synchronizer


### PR DESCRIPTION
I think a lot code has these structure.
```lisp
(defun hoge-topic-callback (msg)
   (setq *hoge* msg))

(ros::subscribe "hoge" foo_msgs::Foo #'hoge-topic-callback)
(ros::spin-once)
(send *hoge* :hoge)
...
```


`topic-listener` class can help these program.
```lisp
(setq *hoge* (instance topic-listener :init "hoge" foo_msgs::Foo)
(ros::spin-once)
(send (send *hoge* :value) :hoge)
...
```

In fact, programmer should not write program which requires this `topic-listener` class but it's a kind of unavoidable hack.