### PR TITLE
[roseus/roseus.cpp] remove trivial error message from get-num-publishers

### DIFF
--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -835,12 +835,6 @@ pointer ROSEUS_GETNUMPUBLISHERS(register context *ctx,int n,pointer *argv)
     bSuccess = true;
   }
 
-  if ( ! bSuccess ) {
-    ROS_ERROR("attempted to getNumPublishers to topic %s, which was not " \
-              "previously subscribed. call (ros::subscribe \"%s\") first.",
-              topicname.c_str(), topicname.c_str());
-  }
-
   return (bSuccess?(makeint(ret)):NIL);
 }
 


### PR DESCRIPTION
I think the error of get-num-publishers is trivial. If calling `get-num-publishers` fails, this returns nil, which is enough to know it fails.