### PR TITLE
[roseus_smach] warning message for :goal-state

### DIFF
--- a/roseus_smach/src/state-machine.l
+++ b/roseus_smach/src/state-machine.l
@@ -78,8 +78,16 @@
   ;;                must be {number,string,symbol} or list of these
   (:add-transition
    (from to exec-result &key (test #'equal))
-   (if (not (derivedp from state))(setq from (or (send self :node from) from)))
-   (if (not (derivedp to state))(setq to (or (send self :node to) to)))
+   (if (not (derivedp from state))
+       (setq from (or (send self :node from)
+                      (progn
+                        (ros::ros-warn "add-transition: Couldn't find ~A state." from)
+                        from))))
+   (if (not (derivedp to state))
+       (setq to (or (send self :node to)
+                    (progn
+                      (ros::ros-warn "add-transition: Couldn't find ~A state." to)
+                      to))))
    (if (and from to)
        (send self :add-arc from to exec-result test)))
   (:add-arc (from to val test)


### PR DESCRIPTION
`:add-node`や `:goal-state`を使ってstate を定義する前に `:add-transition` で遷移を定義すると、state名自体をnode としてしまい、混乱を招く気がしたので、warning messageが出るように変更

例
```
(setq sm (instance state-machine :init))
(send sm :add-node (instance state :init :hoge 'hoge-func))
(send sm :add-transition :hoge :success t)
(send sm :start-state :hoge)
(send sm :goal-state (list :success))
```
などとして実行すると、遷移した結果 `:success` に遷移するが、これは
`(send sm :goal-state (list :success))`
 によって定義された:successと異なるので、
まだ終端に来たと判断せずにエラーが出る。
