### PR TITLE
[.travis.rosinstall] remove mongodb_store from .travis.rosinstall

### DIFF
--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -8,6 +8,3 @@
 - git:
     uri: http://github.com/tork-a/euslisp-release
     local-name: euslisp
-- git:
-    uri: https://github.com/strands-project/mongodb_store
-    local-name: hydro-devel


### PR DESCRIPTION
new version was released on 0.1.18 https://github.com/strands-project/mongodb_store/commit/0d4b0e7813fa5305f964b3ccd8e662e0d6365c67