### PR TITLE
[roseus/euslisp/roseus-utils.l] add image conversion to ros msg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ before_script:
   - if [ "${TRAVIS_SECURE_ENV_VARS}" == "true" ]; then openssl aes-256-cbc -K $encrypted_b79fc5843df3_key -iv $encrypted_b79fc5843df3_iv -in .secrets.tar.enc -out .secrets.tar -d; tar -C ~/ -xvf .secrets.tar; export INSTALL_SRC="$INSTALL_SRC $INSTALL_SRC_SECURE"; export TEST_PKGS="$TEST_PKGS $TEST_PKGS_SECURE"; fi
   - export REPOSITORY_NAME=`basename $PWD`
   - if [ "${INSTALL_SRC}" != "" ] ;then sudo apt-get install python-yaml; rm .travis.rosinstall; for src in $INSTALL_SRC; do name=`basename $src`; python -c "import yaml;print yaml.dump([{'git':{'uri':'$src','local-name':'$name'}}], default_flow_style=False)" >> .travis.rosinstall; done; cat .travis.rosinstall; export USE_DEB=false; fi; # set USE_DEB false to enable .travis.rosinstall
+  - sudo apt-get install xvfb
 script:
   - .travis/travis.sh
 after_success:

--- a/roseus/euslisp/roseus-utils.l
+++ b/roseus/euslisp/roseus-utils.l
@@ -55,6 +55,35 @@
     ;; FIXME:: add coordinates of camera
     (make-camera-from-ros-camera-info-aux pwidth pheight p nil)))
 
+;; Image
+(when (and
+       (assoc :create-viewer (send camera-model :methods))
+       (probe-file (format nil "~A/irteus/demo/sample-camera-model.l" *eusdir*)))
+(defun ros::image->sensor_msgs/Image (img &key header (seq 0) (stamp (ros::time-now)) (frame_id ""))
+  (let ((img24 (swap-rgb (send (send img :copy) :to24)))
+        (msg (instance sensor_msgs::Image :init)))
+    (if header
+        (send msg :header header)
+      (send msg :header
+            (instance std_msgs::header :init
+                      :seq seq :stamp stamp :frame_id frame_id)))
+    (send msg :height (send img24 :height))
+    (send msg :width (send img24 :width))
+    (send msg :step (* (send img24 :width)
+                       (send img24 :components)))
+    (send msg :encoding "bgr8")
+    (send msg :data (send img24 :entity))
+    msg))
+
+(defun ros::sensor_msgs/Image->image (msg)
+  (let ((img24 (instance color-image24 :init
+                         (send msg :width)
+                         (send msg :height)
+                         (copy-object (send msg :data)))))
+    (when (string= (send msg :encoding) "bgr8")
+      (swap-rgb img24))
+    img24)))
+) ;; end of when
 ;;
 ;; 3dpoint cloud
 ;;

--- a/roseus/test/test-roseus.l
+++ b/roseus/test/test-roseus.l
@@ -82,6 +82,35 @@
   (assert (not (ros::resolve-ros-path "package://not_existing_package")))
   )
 
+(deftest test-image-conversion ()
+  (when (and
+         (assoc :create-viewer (send camera-model :methods))
+         (probe-file (format nil "~A/irteus/demo/sample-camera-model.l" *eusdir*)))
+    (load "irteus/demo/sample-camera-model.l")
+    (sample-get-camera-image-2)
+    (setq sndimg (send *camera-model* :get-image))
+    (setq rcvimg nil)
+    (setq seq 0)
+    (ros::advertise "test_image" sensor_msgs::Image 5)
+    (unix:sleep 2)
+    (ros::rate 1)
+
+    (ros::subscribe "test_image" sensor_msgs::Image
+                    #'(lambda (m)
+                        (setq rcvimg (ros::sensor_msgs/Image->image m))))
+
+    (while (and (ros::ok) (null rcvimg))
+      (setq msg (ros::image->sensor_msgs/Image sndimg :seq (inc seq) :frame_id "hoge"))
+      (ros::publish "test_image" msg)
+      (ros::spin-once)
+      (ros::sleep))
+
+    (assert rcvimg "received image")
+    (assert (eq (send rcvimg :width) (send sndimg :width)) "eq image :width")
+    (assert (eq (send rcvimg :height) (send sndimg :height)) "eq image :height")
+    (assert (string= (send rcvimg :entity) (send sndimg :entity)) "eq image :entity")
+    ))
+
 (run-all-tests)
 
 (exit)

--- a/roseus/test/test-roseus.test
+++ b/roseus/test/test-roseus.test
@@ -1,3 +1,3 @@
 <launch>
-  <test test-name="eusroseus" pkg="roseus" type="roseus" args="$(find roseus)/test/test-roseus.l" />
+  <test test-name="eusroseus" pkg="roseus" type="roseus" args="$(find roseus)/test/test-roseus.l" launch-prefix="xvfb-run -a -s '-screen 0 1024x768x24'" />
 </launch>


### PR DESCRIPTION
not yet included test code and docs (I'll make after rinko)
 but like below

@mizmizo you can use this

```lisp
;; test-img.l
;; Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>

(require :pr2 "package://pr2eus/pr2.l")

(ros::roseus "hoge")
(pr2)
(send *pr2* :look-at-target (send *pr2* :rarm :end-coords))

(setq cam (send *pr2* :wide_stereo-left))
(send cam :create-viewer)
(send cam :draw-objects (list *pr2*))
(setq img (send cam :get-image))

(ros::advertise "image" sensor_msgs::Image 5)
(unix:sleep 2)
(setq seq 0)
(ros::rate 10)
(do-until-key
 (setq msg (ros::image->sensor_msgs/Image img :seq (inc seq) :frame_id "hoge"))
 (ros::publish "image" msg)
 (ros::sleep))
```