### PR TITLE
[roseus_mongo] update test launch file along with with fix https://github.com/strands-project/mongodb_store/pull/151

### DIFF
--- a/roseus_mongo/CMakeLists.txt
+++ b/roseus_mongo/CMakeLists.txt
@@ -6,7 +6,6 @@ cmake_minimum_required(VERSION 2.8.3)
 project(roseus_mongo)
 
 find_package(catkin REQUIRED COMPONENTS
-  rostest
   mongodb_store
   mongodb_store_msgs
   roseus
@@ -24,6 +23,14 @@ install(DIRECTORY euslisp
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
   USE_SOURCE_PERMISSIONS)
 
-add_rostest(test/test_json_encode.test)
-add_rostest(test/test_json_decode.test)
-add_rostest(test/test_mongo_client.test)
+if(CATKIN_ENABLE_TESTING)
+  find_package(catkin REQUIRED COMPONENTS rostest)
+  add_rostest(test/test_json_encode.test)
+  add_rostest(test/test_json_decode.test)
+  if(${mongodb_store_VERSION} VERSION_LESS "0.1.17")
+    message(WARNING "detected old mongodb_store. Testing with old launch file")
+    add_rostest(test/test_mongo_client_hydro.test)
+  else()
+    add_rostest(test/test_mongo_client.test)
+  endif()
+endif()

--- a/roseus_mongo/test/temp_mongodb_store.xml
+++ b/roseus_mongo/test/temp_mongodb_store.xml
@@ -1,6 +1,6 @@
 <launch>
   <node pkg="roseus_mongo" type="make_temp_database_dir.sh" name="make_temp_database_dir" />
-  <include file="$(find mongodb_store)/launch/mongodb_store.launch">
+  <include file="$(find mongodb_store)/launch/mongodb_store_inc.launch">
     <arg name="db_path" value="/tmp/mongodb_store" />
     <arg name="port" value="62345" />
     <arg name="use_machine" value="false" />

--- a/roseus_mongo/test/test_mongo_client_hydro.test
+++ b/roseus_mongo/test/test_mongo_client_hydro.test
@@ -1,0 +1,14 @@
+<launch>
+  <param name="robot/database" value="test_database" />
+  <param name="robot/name" value="test_collection" />
+
+  <node pkg="roseus_mongo" type="make_temp_database_dir.sh" name="make_temp_database_dir" />
+  <include file="$(find mongodb_store)/launch/mongodb_store.launch">
+    <arg name="db_path" value="/tmp/mongodb_store" />
+    <arg name="port" value="62345" />
+    <arg name="use_machine" value="false" />
+  </include>
+
+  <test test-name="test_mongo_client" pkg="roseus" type="roseus"
+        args="$(find roseus_mongo)/test/test-mongo-client.l" />
+</launch>


### PR DESCRIPTION
- [roseus_mongo/test/temp_mongodb_store.xml] update launch file path with fix https://github.com/strands-project/mongodb_store/pull/151
- [roseus_mongo/test/test_mongo_client_hydro.test] moved deprecated test launch file for hydro
- [roseus_mongo/CMakeLists.txt] updated to test only CATKIN_ENABLE_TESTING; check mongodb_store version and switch test launch file