### PR TITLE
wait-for-results return nil when no goal has been sent

### DIFF
--- a/roseus/euslisp/actionlib.l
+++ b/roseus/euslisp/actionlib.l
@@ -169,6 +169,10 @@
    (let ((start (ros::time-now))
 	 (result-topic (format nil "~A/result" name-space)))
      (ros::ros-debug "[~A] :wait-for-result ~A, timeout=~A" name-space (if goal_id (send goal_id :id)) timeout)
+     (unless goal_id
+       ;; https://github.com/ros/actionlib/blob/285c60265f18b683b1439accc9603c1e8be30a23/src/actionlib/simple_action_client.py#L128
+       (ros::ros-error "[~A] :wait-for-result (return nil when no goal exists)" name-space)
+       (return-from :wait-for-result nil))
      (ros::rate 10)
      (while (ros::ok)
        (ros::ros-debug "[~A] :wait-for-result ~A ~A" name-space (simple-goal-states-to-string simple-state) (send comm-state :state))

--- a/roseus/test/test-actionlib.l
+++ b/roseus/test/test-actionlib.l
@@ -49,7 +49,7 @@
     (warning-message 2 ";; ~A wait-for-server~%" (unix::getpid))
     (send *c* :wait-for-server)
     (warning-message 2 ";; ~A wait-for-result~%" (unix::getpid))
-    (assert (send *c* :wait-for-result)) ;; note that :wait-for-results returns t even if no goal has need sent
+    (assert (null (send *c* :wait-for-result))) ;; note that :wait-for-results returns nil when no goal has been sent
     ))
 
 (defun fibonacci (n)


### PR DESCRIPTION
CAUTION: behavior change on :wait-for-goal 

change :wait-for-goal to return nil when no goal has been sent, fixed roseus behavior as python case -> https://github.com/ros/actionlib/blob/285c60265f18b683b1439accc9603c1e8be30a23/src/actionlib/simple_action_client.py#L128

this changes the test code, which normally inhibited -> https://github.com/jsk-ros-pkg/jsk_roseus/pull/402/files#diff-d40708ca1dcc5bcbede65b6f65d5dc59R72

- 2630821 (Kei Okada, 26 hours ago)  test/test-actionlib.l: :wait-for-results returns nil when no goal has been sent
- b7461c6 (Kei Okada, 26 hours ago)  wait-for-goal: returns nil when no goal is found