### PR TITLE
disable remove-message test

### DIFF
--- a/roseus/test/test-genmsg.catkin.test
+++ b/roseus/test/test-genmsg.catkin.test
@@ -3,6 +3,6 @@
         time-limit="600" />
   <test test-name="test_geneus_dep1" pkg="roseus" type="test-genmsg.sh" args="--package geneus_dep1"
         time-limit="600" />
-  <test test-name="test_geneus_remove_msg" pkg="roseus" type="test-genmsg.sh" args="--remove-message"
-        time-limit="600" />
+  <!-- test test-name="test_geneus_remove_msg" pkg="roseus" type="test-genmsg.sh" args="[FIXME:minus][FIXME:minus]remove-message"
+        time-limit="600" / -->
 </launch>

--- a/roseus/test/test-genmsg.sh
+++ b/roseus/test/test-genmsg.sh
@@ -49,6 +49,14 @@ while [ $# -gt 0 ]; do
 done
 
 CATKIN_DIR=/tmp/test_genmsg_$$
+
+>&2 echo -e "\e[1;32mRunning test-genmsg.sh $ARGV\e[m"
+>&2 echo -e "\e[1;32m - WORKSPACE_TYPE=${WORKSPACE_TYPE}\e[m"
+>&2 echo -e "\e[1;32m - PACKAGE=${PACKAGE}\e[m"
+>&2 echo -e "\e[1;32m - REMOVE_MSG=${REMOVE_MSG}\e[m"
+>&2 echo -e "\e[1;32m - OUTPUT=${OUTPUT}\e[m"
+>&2 echo -e "\e[1;32m - CATKIN_DIR=${CATKIN_DIR}\e[m"
+
 GENEUS_DEP1=${CATKIN_DIR}/src/geneus_dep1
 GENEUS_DEP2=${CATKIN_DIR}/src/geneus_dep2
 ROSEUS_DEP1=${CATKIN_DIR}/src/roseus_dep1


### PR DESCRIPTION
see #335 (60a4127)

- test/test-genmsg.catkin.test: disable --remove-message test, which does not work on paralllel execution
- test/test-genmsg: add debug message