### PR TITLE
Revert "[roseus/roseus.cpp] remove trivial error message from get-num-publishers"

### DIFF
--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -835,6 +835,12 @@ pointer ROSEUS_GETNUMPUBLISHERS(register context *ctx,int n,pointer *argv)
     bSuccess = true;
   }
 
+  if ( ! bSuccess ) {
+    ROS_ERROR("attempted to getNumPublishers to topic %s, which was not " \
+              "previously subscribed. call (ros::subscribe \"%s\") first.",
+              topicname.c_str(), topicname.c_str());
+  }
+
   return (bSuccess?(makeint(ret)):NIL);
 }
 


### PR DESCRIPTION
Reverts jsk-ros-pkg/jsk_roseus#380

If this is used for `one-shot-subscriber` users, I think we should revert this, besides pub/sub system is not designed to use in 'one-shot' manner, system only depends on one-shot may too dangerous and we can use service call or actionlib

If user calls on-shot-subscriber with unsubscribe t, then we do not need this, and without ubsubscribe it consume heaps and decrease performance.
