### PR TITLE
re-define get_string for osx

### DIFF
--- a/roseus/CMakeLists.txt
+++ b/roseus/CMakeLists.txt
@@ -8,7 +8,6 @@ find_package(catkin REQUIRED COMPONENTS message_generation roslang roscpp rospac
 
 configure_file(${PROJECT_SOURCE_DIR}/bin/roseus.in ${PROJECT_SOURCE_DIR}/bin/roseus @ONLY)
 
-find_package(euslisp REQUIRED)
 add_definitions(-Wall)
 #
 execute_process(COMMAND rosversion tf2_ros OUTPUT_VARIABLE TF2_ROS_VERSION RESULT_VARIABLE TF2_ROS_RESULT OUTPUT_STRIP_TRAILING_WHITESPACE)
@@ -40,14 +39,22 @@ message (STATUS "Build repo revision: ${REPOVERSION}")
 # CATKIN_MIGRATION: removed during catkin migration
 # rosbuild_add_boost_directories()
 
-if(NOT euslisp_INCLUDE_DIRS)
-  if(EXISTS ${euslisp_SOURCE_DIR}/jskeus)
-    set(euslisp_PACKAGE_PATH ${euslisp_SOURCE_DIR})
-  else()
-    set(euslisp_PACKAGE_PATH ${euslisp_PREFIX}/share/euslisp)
+if(APPLE)
+  if(NOT EXISTS /usr/local/opt/jskeus/eus)  # $EUSDIR in OS X
+    message(FATAL_ERROR "jskeus is not installed via Homebrew, Please run `brew install homebrew/x11/jskeus`")
   endif()
-  message("-- Set euslisp_PACKAGE_PATH to ${euslisp_PACKAGE_PATH}")
-  set(euslisp_INCLUDE_DIRS ${euslisp_PACKAGE_PATH}/jskeus/eus/include)
+  set(euslisp_INCLUDE_DIRS /usr/local/opt/jskeus/eus/include)
+else()
+  find_package(euslisp REQUIRED)
+  if(NOT euslisp_INCLUDE_DIRS)
+    if(EXISTS ${euslisp_SOURCE_DIR}/jskeus)
+      set(euslisp_PACKAGE_PATH ${euslisp_SOURCE_DIR})
+    else()
+      set(euslisp_PACKAGE_PATH ${euslisp_PREFIX}/share/euslisp)
+    endif()
+    message("-- Set euslisp_PACKAGE_PATH to ${euslisp_PACKAGE_PATH}")
+    set(euslisp_INCLUDE_DIRS ${euslisp_PACKAGE_PATH}/jskeus/eus/include)
+  endif()
 endif()
 message("-- Set euslisp_INCLUDE_DIRS to ${euslisp_INCLUDE_DIRS}")
 include_directories(/usr/include /usr/X11R6/include ${euslisp_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})

--- a/roseus/cmake/roseus.cmake
+++ b/roseus/cmake/roseus.cmake
@@ -193,9 +193,9 @@ macro(generate_eusdoc _lispfile)
   set(ColourReset "${Esc}[m")
   set(ColourBold  "${Esc}[1m")
   set(Red         "${Esc}[31m")
-  message("running ROS_PACKAGE_PATH=${_ROS_PACKAGE_PATH} CMAKE_PREFIX_PATH=${_CMAKE_PREFIX_PATH} ${_roseus_exe} $ENV{EUSDIR}/lib/llib/documentation.l ${_generate_eusdoc_command_list}")
+  message("running ROS_PACKAGE_PATH=${_ROS_PACKAGE_PATH} CMAKE_PREFIX_PATH=${_CMAKE_PREFIX_PATH} ${_roseus_exe} lib/llib/documentation.l ${_generate_eusdoc_command_list}")
   add_custom_command(OUTPUT ${_mdfile}
-    COMMAND DISPLAY= ROS_PACKAGE_PATH=${_ROS_PACKAGE_PATH} CMAKE_PREFIX_PATH=${_CMAKE_PREFIX_PATH} ${_roseus_exe} $ENV{EUSDIR}/lib/llib/documentation.l ${_generate_eusdoc_command_list} || echo "${Red}Failed to generate ${_lispfile}, but do not raise error${ColourReset}"
+    COMMAND DISPLAY= ROS_PACKAGE_PATH=${_ROS_PACKAGE_PATH} CMAKE_PREFIX_PATH=${_CMAKE_PREFIX_PATH} ${_roseus_exe} lib/llib/documentation.l ${_generate_eusdoc_command_list} || echo "${Red}Failed to generate ${_lispfile}, but do not raise error${ColourReset}"
     DEPENDS ${_lispfile})
   add_custom_target(${PROJECT_NAME}_${_name}_generate_eusdoc ALL DEPENDS ${_mdfile} install_roseus)
   if(TARGET ${PROJECT_NAME}_generate_messages_eus)

--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -85,6 +85,12 @@ extern "C" {
   void register_roseus(){
     char modname[] = "___roseus";
     return add_module_initializer(modname, (pointer (*)())___roseus);}
+  /* get_string is originally defined in lisp/c/makes.c, but it is also defined in Python.so linked from rospack.so
+     to avoid confusion, we have to explictly re-define this method, specially for OSX */
+  byte *get_string(register pointer s){
+    if (isstring(s)) return(s->c.str.chars);
+    if (issymbol(s)) return(s->c.sym.pname->c.str.chars);
+    else error(E_NOSTRING);}
 }
 
 #undef class


### PR DESCRIPTION
another implementation would be define get_string in eus.h as #define and write `#define get_string eus_get_string` in roseus.cpp, but I choose this PR since

- adding get_string to eus.h seems exceptional in other function/macro defined in eus.h
- ??