### PR TITLE
[roseus] fix typo / test: ros::get-param-cached

### DIFF
--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -1379,7 +1379,7 @@ pointer ROSEUS_GET_PARAM(register context *ctx,int n,pointer *argv)
   return (ret);
 }
 
-pointer ROSEUS_GET_PARAM_CASHED(register context *ctx,int n,pointer *argv)
+pointer ROSEUS_GET_PARAM_CACHED(register context *ctx,int n,pointer *argv)
 {
   numunion nu;
   string key;
@@ -1864,7 +1864,7 @@ pointer ___roseus(register context *ctx, int n, pointer *argv, pointer env)
 
   _defun(ctx,"SET-PARAM",argv[0],(pointer (*)())ROSEUS_SET_PARAM, "key value\n\n""Set parameter");
   _defun(ctx,"GET-PARAM",argv[0],(pointer (*)())ROSEUS_GET_PARAM, "key\n\n""Get parameter");
-  _defun(ctx,"GET-PARAM-CASHED",argv[0],(pointer (*)())ROSEUS_GET_PARAM_CASHED, "Get chached parameter");
+  _defun(ctx,"GET-PARAM-CACHED",argv[0],(pointer (*)())ROSEUS_GET_PARAM_CACHED, "Get chached parameter");
   _defun(ctx,"HAS-PARAM",argv[0],(pointer (*)())ROSEUS_HAS_PARAM, "Check whether a parameter exists on the parameter server.");
   _defun(ctx,"DELETE-PARAM",argv[0],(pointer (*)())ROSEUS_DELETE_PARAM, "key\n\n""Delete parameter from server");
 

--- a/roseus/test/param-test.l
+++ b/roseus/test/param-test.l
@@ -4,18 +4,6 @@
 
 (init-unit-test)
 
-(deftest test-param-cache ()
-  (assert (not (ros::has-param "~test")) "[cached ~test] (ros::has-param ~test) returns value")
-
-  (assert (ros::has-param "test")  "[cached] (ros::has-parm test) failed")
-  (let ((ret (ros::get-param "test")))
-    (assert (string= "test_global" (setq as ret)) "[test] test_global != ~A" as))
-
-  (assert (ros::has-param "/test") "[cached, /test] (ros::has-param /test) failed")
-  (let ((ret (ros::get-param "/test")))
-    (assert (string= "test_global" (setq as ret)) "[/test] test_global != ~A" as))
-  )
-
 (deftest test-get-param ()
   (ros::roseus "param_test")
   (assert (ros::has-param "~test") "[~test] (ros::has-param) failed")
@@ -177,6 +165,13 @@
       (assert (not (ros::has-param key)) "(ros::has-param \"~A\") returns value after delete-param" key)))
   (assert (not (ros::has-param "param_not_exists")) "(ros::has-param param_not_exists) returns value")
   (assert (not (ros::delete-param "param_not_exists")) "(ros::delete-param param_not_exists) returns value even if param does not exists"))
+
+(deftest test-param-cache ()
+  (assert (ros::has-param "test")  "[cached] (ros::has-parm test) failed")
+  (assert (string= (ros::get-param "test") (ros::get-param-cached "test")) "(ros::get-param-cached test) has different value from (ros::get-param test): ~A" (ros::get-param-cached "test"))
+  (assert (< (bench2 (dotimes (i 100) (ros::get-param-cached "test")))
+             (bench2 (dotimes (i 100) (ros::get-param "test"))))
+          "(ros::get-param-cached test) has less performance than (ros::get-param test)"))
 
 (run-all-tests)
 


### PR DESCRIPTION
- `ros::get-param-cashed` -> `ros::get-param-cached`
- fix test for cache

This pull request should be merged after https://github.com/jsk-ros-pkg/jsk_roseus/pull/466