### PR TITLE
[roseus] fix config of dependency: coreutils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ env:
     - ROS_PARALLEL_TEST_JOBS="-j2"
     - CATKIN_PARALLEL_TEST_JOBS="-p2"
   matrix:
-    - ROS_DISTRO=hydro  USE_DEB=true
-    - ROS_DISTRO=hydro  USE_DEB=true       ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - ROS_DISTRO=hydro  USE_DEB=false      NOT_TEST_INSTALL=true
-    - ROS_DISTRO=hydro  USE_DEB=true       NOT_TEST_INSTALL=true INSTALL_SRC="http://github.com/jsk-ros-pkg/jsk_pr2eus" TEST_PKGS="pr2eus"
-    - ROS_DISTRO=hydro  USE_DEB=true       NOT_TEST_INSTALL=true BEFORE_SCRIPT="git clone -b hydro-devel http://github.com/ros/geometry; git clone -b hydro-devel http://github.com/ros/geometry-experimental; touch jsk_roseus/roseus_tutorials/CATKIN_IGNORE; touch geometry-experimental/test_tf2/CATKIN_IGNORE" # need to ignore roseus_tutorials which depends on image_view2 and that install deb version of tf/tf2
-    - ROS_DISTRO=hydro  USE_DEB=source
+    - ROS_DISTRO=hydro  USE_DEB=true CATKIN_TOOLS_BUILD_OPTIONS="-iv --summarize --no-status"
+    - ROS_DISTRO=hydro  USE_DEB=true CATKIN_TOOLS_BUILD_OPTIONS="-iv --summarize --no-status"      ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO=hydro  USE_DEB=false CATKIN_TOOLS_BUILD_OPTIONS="-iv --summarize --no-status"      NOT_TEST_INSTALL=true
+    - ROS_DISTRO=hydro  USE_DEB=true CATKIN_TOOLS_BUILD_OPTIONS="-iv --summarize --no-status"       NOT_TEST_INSTALL=true INSTALL_SRC="http://github.com/jsk-ros-pkg/jsk_pr2eus" TEST_PKGS="pr2eus"
+    - ROS_DISTRO=hydro  USE_DEB=true CATKIN_TOOLS_BUILD_OPTIONS="-iv --summarize --no-status"       NOT_TEST_INSTALL=true BEFORE_SCRIPT="git clone -b hydro-devel http://github.com/ros/geometry; git clone -b hydro-devel http://github.com/ros/geometry-experimental; touch jsk_roseus/roseus_tutorials/CATKIN_IGNORE; touch geometry-experimental/test_tf2/CATKIN_IGNORE" # need to ignore roseus_tutorials which depends on image_view2 and that install deb version of tf/tf2
+    - ROS_DISTRO=hydro  USE_DEB=source CATKIN_TOOLS_BUILD_OPTIONS="-iv --summarize --no-status"
     - ROS_DISTRO=indigo USE_DEB=true
     - ROS_DISTRO=indigo USE_DEB=true       ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - ROS_DISTRO=indigo USE_DEB=false      NOT_TEST_INSTALL=true
@@ -34,7 +34,7 @@ env:
     - ROS_DISTRO=jade USE_DEB=source     TEST_PKGS="roseus roseus_smach" NOT_TEST_INSTALL=true
 matrix:
   allow_failures:
-    - env: ROS_DISTRO=hydro  USE_DEB=true       ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - env: ROS_DISTRO=hydro  USE_DEB=true CATKIN_TOOLS_BUILD_OPTIONS="-iv --summarize --no-status"      ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
     - env: ROS_DISTRO=jade USE_DEB=true       TEST_PKGS="roseus roseus_smach" NOT_TEST_INSTALL=true
     - env: ROS_DISTRO=jade USE_DEB=true       ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu TEST_PKGS="roseus roseus_smach" NOT_TEST_INSTALL=true
 #     - env: ROS_DISTRO=hydro  ROSWS=wstool BUILDER=catkin    USE_DEB=false

--- a/roseus/CMakeLists.txt
+++ b/roseus/CMakeLists.txt
@@ -137,7 +137,7 @@ add_custom_target(install_roseus ALL DEPENDS ${CATKIN_DEVEL_PREFIX}/bin/roseus r
 ## CATKIN_DEPENDS: catkin_packages dependent projects also need
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
-    DEPENDS roslang roscpp rospack actionlib actionlib_msgs visualization_msgs tf geometry_msgs std_msgs std_srvs sensor_msgs visualization_msgs actionlib_tutorials coreutils tf2_ros
+    DEPENDS roslang roscpp rospack actionlib actionlib_msgs visualization_msgs tf geometry_msgs std_msgs std_srvs sensor_msgs visualization_msgs actionlib_tutorials tf2_ros
     CATKIN_DEPENDS message_runtime # euslisp TODO
     INCLUDE_DIRS # TODO include
     LIBRARIES # TODO

--- a/roseus/package.xml
+++ b/roseus/package.xml
@@ -40,6 +40,7 @@
   <build_depend>message_generation</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>actionlib_tutorials</build_depend>
+  <build_depend>coreutils</build_depend>
 
   <run_depend>geneus</run_depend>
   <run_depend>rosbash</run_depend>


### PR DESCRIPTION
reported at http://jenkins.jsk.imi.i.u-tokyo.ac.jp:8080/job/trusty-travis-jsk-ros-pkg-jsk_roseus-indigo-deb-false-true/927/console

```
[roseus:cmake] -- roseus: 4 messages, 2 services

09:57:06 

                                                                                
[roseus:cmake] CMake Error at /opt/ros/indigo/share/catkin/cmake/catkin_package.cmake:163 (message):

09:57:06 
                                                                                
[roseus:cmake]   catkin_package() DEPENDS on 'coreutils' which must be find_package()-ed

09:57:06 
                                                                                
[roseus:cmake]   before.  If it is a catkin package it can be declared as CATKIN_DEPENDS

09:57:06 
                                                                                
[roseus:cmake]   instead without find_package()-ing it.

09:57:06 
                                                                                
[roseus:cmake] Call Stack (most recent call first):

09:57:06 
                                                                                
[roseus:cmake]   /opt/ros/indigo/share/catkin/cmake/catkin_package.cmake:102 (_catkin_package)

09:57:06 
                                                                                
[roseus:cmake]   CMakeLists.txt:139 (catkin_package)
```