### PR TITLE
[roseus] Remove definition of unused variables in roseus.cpp

### DIFF
--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -1221,11 +1221,8 @@ void EusValueToXmlRpc(register context *ctx, pointer argp, XmlRpc::XmlRpcValue& 
 
 pointer ROSEUS_SET_PARAM(register context *ctx,int n,pointer *argv)
 {
-  numunion nu;
   string key;
   string s;
-  double d;
-  int i;
 
   ckarg(2);
   if (isstring(argv[0])) key.assign((char *)get_string(argv[0]));
@@ -1471,7 +1468,6 @@ pointer ROSEUS_ROSPACK_PLUGINS(register context *ctx,int n,pointer *argv)
   // (ros::rospack-plugins package-name attibute-name)
   ckarg(2);
   string pkg, attrib;
-  numunion nu;
   pointer ret, first;
   if (isstring(argv[0])) pkg.assign((char *)get_string(argv[0]));
   else error(E_NOSTRING);
@@ -1650,7 +1646,7 @@ class TimerFunction
   pointer _scb, _args;
 public:
   TimerFunction(pointer scb, pointer args) : _scb(scb), _args(args) {
-    context *ctx = current_ctx;
+    //context *ctx = current_ctx;
     //ROS_WARN("func");prinx(ctx,scb,ERROUT);flushstream(ERROUT);terpri(ERROUT);
     //ROS_WARN("argc");prinx(ctx,args,ERROUT);flushstream(ERROUT);terpri(ERROUT);
   }
@@ -1658,7 +1654,6 @@ public:
   {
     mutex_trylock(&mark_lock);
     context *ctx = current_ctx;
-    numunion nu;
     pointer argp=_args;
     int argc=0;
 


### PR DESCRIPTION
```
[roseus] /home/wkentaro/ros/indigo/src/jsk-ros-pkg/jsk_roseus/roseus/roseus.cpp: In function cell* ROSEUS_SET_PARAM(context*, int, cell**):
[roseus] /home/wkentaro/ros/indigo/src/jsk-ros-pkg/jsk_roseus/roseus/roseus.cpp:1224:12: warning: unused variable nu [-Wunused-variable]
[roseus]    numunion nu;
[roseus]             ^
[roseus] /home/wkentaro/ros/indigo/src/jsk-ros-pkg/jsk_roseus/roseus/roseus.cpp:1227:10: warning: unused variable d [-Wunused-variable]
[roseus]    double d;
[roseus]           ^
[roseus] /home/wkentaro/ros/indigo/src/jsk-ros-pkg/jsk_roseus/roseus/roseus.cpp:1228:7: warning: unused variable i [-Wunused-variable]
[roseus]    int i;
[roseus]        ^
[roseus] /home/wkentaro/ros/indigo/src/jsk-ros-pkg/jsk_roseus/roseus/roseus.cpp: In function cell* ROSEUS_ROSPACK_PLUGINS(context*, int, cell**):
[roseus] /home/wkentaro/ros/indigo/src/jsk-ros-pkg/jsk_roseus/roseus/roseus.cpp:1474:12: warning: unused variable nu [-Wunused-variable]
[roseus]    numunion nu;
[roseus]             ^
[roseus] /home/wkentaro/ros/indigo/src/jsk-ros-pkg/jsk_roseus/roseus/roseus.cpp: In constructor TimerFunction::TimerFunction(pointer, pointer):
[roseus] /home/wkentaro/ros/indigo/src/jsk-ros-pkg/jsk_roseus/roseus/roseus.cpp:1653:14: warning: unused variable ctx [-Wunused-variable]
[roseus]      context *ctx = current_ctx;
[roseus]               ^
[roseus] /home/wkentaro/ros/indigo/src/jsk-ros-pkg/jsk_roseus/roseus/roseus.cpp: In member function void TimerFunction::operator()(const ros::TimerEvent&):
[roseus] /home/wkentaro/ros/indigo/src/jsk-ros-pkg/jsk_roseus/roseus/roseus.cpp:1661:14: warning: unused variable nu [-Wunused-variable]
[roseus]      numunion nu;
[roseus]               ^
[roseus] /home/wkentaro/ros/indigo/src/jsk-ros-pkg/jsk_roseus/roseus/roseus.cpp: In function byte* get_string(pointer):
[roseus] /home/wkentaro/ros/indigo/src/jsk-ros-pkg/jsk_roseus/roseus/roseus.cpp:93:28: warning: control reaches end of non-void function [-Wreturn-type]
[roseus]      else error(E_NOSTRING);}
[roseus]                             ^
[roseus] /home/wkentaro/ros/indigo/src/jsk-ros-pkg/jsk_roseus/roseus/roseus.cpp: In function cell* ROSEUS_CREATE_TIMER(context*, int, cell**):
[roseus] /home/wkentaro/ros/indigo/src/jsk-ros-pkg/jsk_roseus/roseus/roseus.cpp:1703:11: warning: fncallback may be used uninitialized in this function [-Wmaybe-uninitialized]
[roseus]    pointer fncallback, args;
[roseus]            ^
```