### PR TITLE
[roseus_mongo] query mongo server with timeout option

### DIFF
--- a/roseus_mongo/README.md
+++ b/roseus_mongo/README.md
@@ -31,8 +31,8 @@ roseus_mongo
   
 - `*mongo-service-timeout*` (int, default: param `~timeout` or 30)
 
-  Seconds to wait for database server. Setting this value to `0` means waiting forever.
-  On euslisp only simulation without mongodb, it is recommended to set this value to `1` to avoid stuck.
+  Seconds to wait for database server. Setting this value to `-1` means waiting forever.
+  On euslisp only simulation without mongodb, it is recommended to set this value to `0` to avoid stuck.
 
 ### json(bson) related parameters
 

--- a/roseus_mongo/README.md
+++ b/roseus_mongo/README.md
@@ -5,17 +5,44 @@ roseus_mongo
 
 ### mongodb related parameters
 
-- `*mongo-database*`: database name used by mongodb (default: param `robot/database` or "test")
-- `*mongo-collection*`: collection name used by mongodb (default: param `robot/name` or "test")
-- `*mongo-query-default-buffer-size*`: buffer size reserved for storing json raw string while translation (default: 4096 [byte])
-- `*mongo-service-query*`: service name of querying message (default: "/message_store/query_messages")
-- `*mongo-service-insert*`: service name of inserting message (default: "/message_store/insert")
-- `*mongo-service-delete*`: service name of deleting message (default: "/message_store/delete")
+- `*mongo-database*` (string, default: param `robot/database` or `test`)
+
+  Database name used by mongodb
+
+- `*mongo-collection*` (string, default: param `robot/name` or `test`)
+
+  Collection name used by mongodb
+
+- `*mongo-query-default-buffer-size*` (int, default 4096 [byte])
+
+  Buffer size reserved for storing json raw string while serialization
+
+- `*mongo-service-query*` (string, default: `/message_store/query_messages`)
+
+  Service name for querying message
+  
+- `*mongo-service-insert*` (string, default: `/message_store/insert`)
+
+  Service name for inserting message
+  
+- `*mongo-service-delete*` (string, default: `/message_store/delete`)
+
+  Service name for deleting message
+  
+- `*mongo-service-timeout*` (int, default: param `~timeout` or 30)
+
+  Seconds to wait for database server. Setting this value to `0` means waiting forever.
+  On euslisp only simulation without mongodb, it is recommended to set this value to `1` to avoid stuck.
 
 ### json(bson) related parameters
 
-- `*json-parse-object-as*`: destination type of evaluating json object (`:alist` or `:plist`, default: `:alist`)
-- `*json-parse-key-function*`: destination type of key when evaluation json object (`#'identity`, `#'string->keyword` or possible other functions, default: `#'string->keyword`)
+- `*json-parse-object-as*` (`:alist` or `:plist`, default: `:alist`)
+
+  Destination type of evaluating json object
+  
+- `*json-parse-key-function*` (`#'identity`, `#'string->keyword` or possible other functions, default: `#'string->keyword`)
+
+  Destination type of key when evaluation json object
 
 
 ## How to use

--- a/roseus_mongo/euslisp/mongo-client.l
+++ b/roseus_mongo/euslisp/mongo-client.l
@@ -14,18 +14,22 @@
 (defvar *mongo-service-query* "/message_store/query_messages")
 (defvar *mongo-service-insert* "/message_store/insert")
 (defvar *mongo-service-delete* "/message_store/delete")
+(defvar *mongo-service-timeout* (ros::get-param "~timeout" 30))
 
 (unless (find-package "MONGO") (make-package "MONGO"))
 (in-package "MONGO")
 
 (defun wait-for-server ()
-  (ros::wait-for-service "/datacentre/wait_ready")
+  (unless (ros::wait-for-service "/datacentre/wait_ready" user::*mongo-service-timeout*)
+    (ros::ros-warn "timeout. mongodb server is not ready.")
+    (return-from wait-for-server nil))
   (user::call-empty-service "/datacentre/wait_ready")
   (unix:sleep 2))
 
 (defun shutdown-server ()
-  (ros::wait-for-service "/datacentre/shutdown")
-  (user::call-empty-service "/datacentre/shutdown"))
+  (when (ros::wait-for-service "/datacentre/shutdown")
+    (user::call-empty-service "/datacentre/shutdown")
+    (ros::ros-info "send shutdown signal to mongodb server")))
 
 (defun apply-to-ros-query (encoder lst)
   (let ((ss (make-string-output-stream user::*mongo-query-default-buffer-size*)))
@@ -62,7 +66,10 @@
       (send req :meta_query (apply-to-ros-query encoder meta)))
     (when sort
       (send req :sort_query (apply-to-ros-query encoder sort)))
-    (ros::wait-for-service user::*mongo-service-query*)
+    (unless
+        (ros::wait-for-service user::*mongo-service-query* user::*mongo-service-timeout*)
+      (ros::ros-warn "wait-for-service ~A timeout." user::*mongo-service-query*)
+      (return-from query nil))
     (setq res (ros::service-call user::*mongo-service-query* req))
     (mapcar #'(lambda (message meta-pair)
                 (let ((msg (instance msg-type :init))
@@ -82,7 +89,10 @@
                                  :msg (send msg :serialize)))
     (when meta
       (send req :meta (apply-to-ros-query encoder meta)))
-    (ros::wait-for-service user::*mongo-service-insert*)
+    (unless
+        (ros::wait-for-service user::*mongo-service-insert* user::*mongo-service-timeout*)
+      (ros::ros-warn "wait-for-service ~A timeout." user::*mongo-service-insert*)
+      (return-from insert nil))
     (setq res (ros::service-call user::*mongo-service-insert* req))
     (send res :id)))
 
@@ -92,7 +102,10 @@
     (send req :database user::*mongo-database*)
     (send req :collection user::*mongo-collection*)
     (send req :document_id id)
-    (ros::wait-for-service user::*mongo-service-delete*)
+    (unless
+        (ros::wait-for-service user::*mongo-service-delete* user::*mongo-service-timeout*)
+      (ros::ros-warn "wait-for-service ~A timeout." user::*mongo-service-delete*)
+      (return-from delete-by-id nil))
     (setq res (ros::service-call user::*mongo-service-delete* req))
     (send res :success)))
 
@@ -112,8 +125,8 @@
                                                :data collections)
                         :move_before move-before
                         :delete_after_move delete-after-move))))
-    (when (not (send c :wait-for-server 30))
-      (ros::ros-error "no response from server..")
+    (unless (send c :wait-for-server user::*mongo-service-timeout*)
+      (ros::ros-warn "wait-for-server /move_mongodb_entries timeout")
       (return-from replicate nil))
     (send c :send-goal-and-wait goal))
   t)

--- a/roseus_mongo/test/test-mongo-client.l
+++ b/roseus_mongo/test/test-mongo-client.l
@@ -52,6 +52,19 @@
       (assert (eq (float i) (send (elt assume-5-msgs i) :position :x)))))
 )
 
+(deftest mongo-client-timeout ()
+  (setq *mongo-service-timeout* 1)
+  (setq *mongo-service-insert* "/dummy/insert")
+
+  (setq start-time (ros::time-now))
+  (setq msg (instance geometry_msgs::Pose :init
+                      :position (instance geometry_msgs::Point :init :x 1 :y 2 :z 3)))
+  (setq doc-id (mongo::insert msg))
+  (setq elapsed-time (ros::time- (ros::time-now) start-time))
+  (assert (null doc-id))
+  (assert (< (send elapsed-time :to-sec) 2)))
+
+
 (run-all-tests)
 (exit)
 


### PR DESCRIPTION
calling `(mongo::query msg)` without mongodb server stucks on waiting server response forever.
This pull request sets `~timeout` option to avoid this stuck.

- [README.md] refactor markdown. / add description for timeout option
- [euslisp/mongo-client.l] support timeout
- [test/test-mongo-client.l] add test for query with timeout