### PR TITLE
[roseus_smach/src/pddl2smach.l] use function namespace to call

### DIFF
--- a/roseus_smach/src/pddl2smach.l
+++ b/roseus_smach/src/pddl2smach.l
@@ -56,9 +56,9 @@
                  (if use-userdata
                      (setq func
                            `(lambda-closure nil 0 0 (userdata)
-                                            (apply ',(car sym) userdata ',(cdr sym))))
+                                            (apply #',(car sym) userdata ',(cdr sym))))
                    (setq func
-                         `(lambda-closure nil 0 0 (x) (apply ',(car sym) ',(cdr sym)))))
+                         `(lambda-closure nil 0 0 (x) (apply #',(car sym) ',(cdr sym)))))
                  (cond
                   (readable
                    (if use-sub-machine


### PR DESCRIPTION
double check to avoid error reported at https://github.com/euslisp/EusLisp/issues/210