### PR TITLE
[roseus_mongo][json-decode.l] fix: parse-number / constant return only string

### DIFF
--- a/roseus_mongo/euslisp/json/json-decode.l
+++ b/roseus_mongo/euslisp/json/json-decode.l
@@ -80,14 +80,14 @@
     (let ((str (get-output-stream-string os)))
       (cond
        ((string= str "true")
-        t)
+        (return-from parse-constant t))
        ((string= str "null")
-        nil)
+        (return-from parse-constant nil))
        ((and (peek-char is nil nil)
              (string= "false"
                       (concatenate string str
                        (format nil "~c" (read-char is)))))
-        nil)
+        (return-from parse-constant nil))
        (t
         (error "~A is not a constant" str))))))
 
@@ -96,7 +96,7 @@
    (while (position (peek-char is nil nil) ".0123456789+-Ee")
      (write-byte (read-char is) os))
    (let ((num? (read-from-string (get-output-stream-string os))))
-     (if (numberp num?) num?
+     (if (numberp num?) (return-from parse-number num?)
        (error "~A is not a number" num?)))))
 
 (defun parse-array (is)


### PR DESCRIPTION
fix: from comment https://github.com/jsk-ros-pkg/jsk_roseus/commit/4fd758ce55ec64cf21098a14098d4d7d9570148a#commitcomment-20430551