### PR TITLE
[roseus_mongo] fix: timeout must be integer

### DIFF
--- a/roseus_mongo/euslisp/mongo-client.l
+++ b/roseus_mongo/euslisp/mongo-client.l
@@ -14,7 +14,7 @@
 (defvar *mongo-service-query* "/message_store/query_messages")
 (defvar *mongo-service-insert* "/message_store/insert")
 (defvar *mongo-service-delete* "/message_store/delete")
-(defvar *mongo-service-timeout* (ros::get-param "~timeout" 30))
+(defvar *mongo-service-timeout* (floor (ros::get-param "~timeout" 30)))
 
 (unless (find-package "MONGO") (make-package "MONGO"))
 (in-package "MONGO")

--- a/roseus_mongo/test/test_mongo_client.test
+++ b/roseus_mongo/test/test_mongo_client.test
@@ -11,5 +11,7 @@
   </include>
 
   <test test-name="test_mongo_client" pkg="roseus" type="roseus"
-        args="$(find roseus_mongo)/test/test-mongo-client.l" />
+        args="$(find roseus_mongo)/test/test-mongo-client.l">
+    <param name="timeout" value="10"/>
+  </test>
 </launch>


### PR DESCRIPTION
`ros::get-param` always returns numerial value as `double` instead `*mongo-service-timeout*` assumes parameter as `integer`.