### PR TITLE
remove compiler warning from roseus.cpp

### DIFF
--- a/roseus/CMakeLists.txt
+++ b/roseus/CMakeLists.txt
@@ -68,7 +68,7 @@ set_target_properties(eustf PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE
 set_target_properties(roseus_c_util PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/euslisp)
 
 # compile flags
-add_definitions(-O2 -DNDEBUG -Wno-write-strings -Wdelete-non-virtual-dtor -Wno-unused-but-set-variable -Wno-comment)
+add_definitions(-O2 -DNDEBUG -Wno-write-strings -Wno-unused-but-set-variable -Wno-comment)
 add_definitions(-Di486 -DLinux -D_REENTRANT -DVERSION='\"9.00\"' -DTHREADED -DPTHREAD -DX11R6_1)
 add_definitions('-DREPOVERSION="\\"${REPOVERSION}\\""')
 if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "amd64(.*)" OR

--- a/roseus/CMakeLists.txt
+++ b/roseus/CMakeLists.txt
@@ -68,7 +68,7 @@ set_target_properties(eustf PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE
 set_target_properties(roseus_c_util PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/euslisp)
 
 # compile flags
-add_definitions(-O2 -DNDEBUG -Wno-write-strings -Wno-comment)
+add_definitions(-O2 -DNDEBUG -Wno-write-strings -Wdelete-non-virtual-dtor -Wno-unused-but-set-variable -Wno-comment)
 add_definitions(-Di486 -DLinux -D_REENTRANT -DVERSION='\"9.00\"' -DTHREADED -DPTHREAD -DX11R6_1)
 add_definitions('-DREPOVERSION="\\"${REPOVERSION}\\""')
 if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "amd64(.*)" OR

--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -90,7 +90,7 @@ extern "C" {
   byte *get_string(register pointer s){
     if (isstring(s)) return(s->c.str.chars);
     if (issymbol(s)) return(s->c.sym.pname->c.str.chars);
-    else error(E_NOSTRING);}
+    else error(E_NOSTRING); return NULL; }
 }
 
 #undef class
@@ -285,7 +285,8 @@ public:
     a = (pointer)findmethod(ctx,K_ROSEUS_DESERIALIZE,classof(_message),&curclass);
     ROS_ASSERT(a!=NIL);
     pointer p = makestring((char *)readPtr, sz);
-    pointer r = csend(ctx,_message,K_ROSEUS_DESERIALIZE,1,p);
+    pointer r;
+    r = csend(ctx,_message,K_ROSEUS_DESERIALIZE,1,p);
     ROS_ASSERT(r!=NIL);
     //ROS_INFO("deserialize %d", __serialized_length);
     vpop(); // pop _message
@@ -1702,7 +1703,7 @@ pointer ROSEUS_CREATE_TIMER(register context *ctx,int n,pointer *argv)
   isInstalledCheck;
   numunion nu;
   bool oneshot = false;
-  pointer fncallback, args;
+  pointer fncallback = NIL, args;
   NodeHandle *lnode = s_node.get();
   string fncallname;
   float period=ckfltval(argv[0]);

--- a/roseus/roseus_c_util.c
+++ b/roseus/roseus_c_util.c
@@ -10,8 +10,8 @@
 #include "eus.h"
 
 extern pointer ___roseus_c_util();
-static void register_roseus_c_util()
-  { add_module_initializer("___roseus_c_util", ___roseus_c_util);}
+//static void register_roseus_c_util()
+//  { add_module_initializer("___roseus_c_util", ___roseus_c_util);}
 
 #define colsize(p) (intval(p->c.ary.dim[1]))
 #define rowsize(p) (intval(p->c.ary.dim[0]))


### PR DESCRIPTION
```
Warnings   << roseus:make /home/k-okada/catkin_ws/ws_roseus/logs/roseus/build.make.009.log
/home/k-okada/catkin_ws/ws_roseus/src/jsk_roseus/roseus/roseus.cpp: In member function ‘uint32_t EuslispMessage::serializationLength() const’:
/home/k-okada/catkin_ws/ws_roseus/src/jsk_roseus/roseus/roseus.cpp:250:13: warning: variable ‘a’ set but not used [-Wunused-but-set-variable]
     pointer a,curclass;
             ^
/home/k-okada/catkin_ws/ws_roseus/src/jsk_roseus/roseus/roseus.cpp: In member function ‘virtual uint8_t* EuslispMessage::serialize(uint8_t*, uint32_t) const’:
/home/k-okada/catkin_ws/ws_roseus/src/jsk_roseus/roseus/roseus.cpp:260:13: warning: variable ‘a’ set but not used [-Wunused-but-set-variable]
     pointer a,curclass;
             ^
/home/k-okada/catkin_ws/ws_roseus/src/jsk_roseus/roseus/roseus.cpp: In member function ‘virtual uint8_t* EuslispMessage::deserialize(uint8_t*, uint32_t)’:
/home/k-okada/catkin_ws/ws_roseus/src/jsk_roseus/roseus/roseus.cpp:278:13: warning: variable ‘a’ set but not used [-Wunused-but-set-variable]
     pointer a,curclass;
             ^
/home/k-okada/catkin_ws/ws_roseus/src/jsk_roseus/roseus/roseus.cpp:288:13: warning: unused variable ‘r’ [-Wunused-variable]
     pointer r = csend(ctx,_message,K_ROSEUS_DESERIALIZE,1,p);
             ^
/home/k-okada/catkin_ws/ws_roseus/src/jsk_roseus/roseus/roseus.cpp: In function ‘byte* get_string(pointer)’:
/home/k-okada/catkin_ws/ws_roseus/src/jsk_roseus/roseus/roseus.cpp:93:28: warning: control reaches end of non-void function [-Wreturn-type]
     else error(E_NOSTRING);}
                            ^
/home/k-okada/catkin_ws/ws_roseus/src/jsk_roseus/roseus/roseus.cpp: In function ‘cell* ROSEUS_CREATE_TIMER(context*, int, cell**)’:
/home/k-okada/catkin_ws/ws_roseus/src/jsk_roseus/roseus/roseus.cpp:1705:11: warning: ‘fncallback’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   pointer fncallback, args;
```