### PR TITLE
CMakeLists.txt: use grep package.xml when git --tags did not retun any message (it happens in build farm)

### DIFF
--- a/roseus/CMakeLists.txt
+++ b/roseus/CMakeLists.txt
@@ -29,10 +29,16 @@ endif()
 
 
 set(ENV{LANG} "C")
-execute_process (COMMAND git rev-parse --short HEAD
+execute_process (COMMAND git describe --tags HEAD
   WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
   OUTPUT_VARIABLE REPOVERSION
   OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(NOT REPOVERSION)
+  execute_process(COMMAND grep version ${PROJECT_SOURCE_DIR}/package.xml
+    COMMAND sed -e s/[^0-9.]//g
+    OUTPUT_VARIABLE REPOVERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()
 message (STATUS "Build repo revision: ${REPOVERSION}")
 
 #


### PR DESCRIPTION
compiled version of roseus displays
```
roseus ;; loading roseus("") on euslisp((9.23 ip-172-31-23-158 Mon Mar 13 06:38:31 PDT 2017  1.1.0))
```

this should be
```
roseus ;; loading roseus("1.6.1") on euslisp((9.23 ip-172-31-23-158 Mon Mar 13 06:38:31 PDT 2017  1.1.0))
```