### PR TITLE
[roseus_smach] add root-name key in exec-state-machine

### DIFF
--- a/roseus_smach/sample/parallel-state-machine-sample.l
+++ b/roseus_smach/sample/parallel-state-machine-sample.l
@@ -70,7 +70,7 @@
 (defun demo ()
   (when (or (not (boundp '*sm*)) (not (boundp '*wash*)))
     (init))
-  (exec-smach-with-spin *sm*))
+  (exec-state-machine *sm*))
 
 (warning-message 3 ";; (demo)~%")
 

--- a/roseus_smach/src/state-machine-utils.l
+++ b/roseus_smach/src/state-machine-utils.l
@@ -1,7 +1,7 @@
 ;; state-machine-utils.l
 
 (defun exec-state-machine (sm &optional mydata
-                           &key (spin t) (hz 1) iterate)
+                           &key (spin t) (hz 1) (root-name "SM_ROOT") iterate)
   "Execute state machine
 
 Args:
@@ -14,7 +14,7 @@ Args:
 Returns:
   the last active state
 "
-  (let ((insp (instance state-machine-inspector :init sm)))
+  (let ((insp (instance state-machine-inspector :init sm :root-name root-name)))
     (unix::sleep 2)
     (send sm :reset-state)
     (send insp :publish-structure) ;; publish once and latch

--- a/roseus_smach/test/test-parallel-state-machine.l
+++ b/roseus_smach/test/test-parallel-state-machine.l
@@ -15,6 +15,10 @@
   (assert (eq (send (exec-state-machine *sm*) :name) :success)
           "test parallel state machine sample"))
 
+(deftest test-parallel-state-machine-with-root-name
+  (assert (eq (send (exec-state-machine *sm* nil :root-name "SM_ROOT_1") :name) :success)
+          "test parallel state machine sample with root name"))
+
 (run-all-tests)
 
 (exit)


### PR DESCRIPTION
add `:root-name` key to `exec-state-machine` function.
this is for two state machine running parallel.
![two_state_machine](https://cloud.githubusercontent.com/assets/9300063/26717302/e73a73a0-47b7-11e7-97dd-fc36518abcd6.png)
