### PR TITLE
[roseus_utils.l] fix make-camera-from-ros-camera-info-aux

### DIFF
--- a/roseus/euslisp/roseus-utils.l
+++ b/roseus/euslisp/roseus-utils.l
@@ -42,7 +42,10 @@
 (defun make-camera-from-ros-camera-info-aux (pwidth pheight p frame-coords &rest args)
   (let* ((fx (elt p 0))(fy (elt p 5))
          (cx (elt p 2))(cy (elt p 6))
-         (tx (elt p 3))(ty (elt p 7)))
+         (fx*tx (elt p 3))(fy*ty (elt p 7))
+         (tx (* 1000 (/ fx*tx fx)))
+         (ty (* 1000 (/ fy*ty fy)))
+         )
     (apply #'make-camera-from-param :pwidth pwidth :pheight pheight
 	   :fx fx :fy fy :cx cx :cy cy
 	   :tx tx :ty ty :parent-coords frame-coords args)))


### PR DESCRIPTION
```make-camera-from-ros-camera-info-aux``` may return wrong camera position
if projection matrix has base_line (it is for stereo cameras)

definition of CameraInfo // (elt P 3) = fx * base_line[m]
https://github.com/ros/common_msgs/blob/jade-devel/sensor_msgs/msg/CameraInfo.msg#L97-L98

current make-camera-from-ros-camera-info-aux // tx = (elt P 3), fx = (elt P 0)
https://github.com/jsk-ros-pkg/jsk_roseus/blob/master/roseus/euslisp/roseus-utils.l#L42-L48

implementation of jskeus // tx = base_line[mm], fx = fx
https://github.com/euslisp/jskeus/blob/master/irteus/irtsensor.l#L388-L393

So, it requires unit conversion [mm -> m] and calc baseline from (elt P 3).

After this PR, eus model is changed collectly.
https://github.com/jsk-ros-pkg/jsk_pr2eus/blob/master/pr2eus/make-pr2-model-file.l
~~~
;; using current model
(send (send *pr2-stable* :camera :narrow_stereo/left) :transformation (send *pr2-stable* :camera :narrow_stereo/right))
--> #<coordinates #X6d922b0  81.625 0.0 -2.842e-14 / 0.0 0.0 0.0>
(send (send *pr2-stable* :camera :wide_stereo/left) :transformation (send *pr2-stable* :camera :wide_stereo/right))
--> #<coordinates #X6daea60  39.952 -2.274e-13 0.0 / 0.0 0.0 0.0>

;; using model after applied this PR
(send (send *pr2-unstable* :camera :narrow_stereo/left) :transformation (send *pr2-unstable* :camera :narrow_stereo/right))
--> #<coordinates #X6d8b8a8  89.627 0.0 0.0 / 0.0 0.0 0.0>
(send (send *pr2-unstable* :camera :wide_stereo/left) :transformation (send *pr2-unstable* :camera :wide_stereo/right))
--> #<coordinates #X6d94020  89.653 0.0 0.0 / 0.0 0.0 0.0>
~~~

Figures shows left camera coords (black), current right camera coords (blue) and  new right camera coords (red).

narrow_stereo
![pr2_narrow](https://user-images.githubusercontent.com/2408164/27223121-26bf5ffa-52ca-11e7-960e-de62633ebcaa.png)

wide_stereo
![pr2_wide](https://user-images.githubusercontent.com/2408164/27223131-2b06b43c-52ca-11e7-87c2-8876e2ad61c6.png)

