### PR TITLE
[roseus/euslisp/actionlib.l] fix :wait-for-result is too slow

### DIFF
--- a/roseus/euslisp/actionlib.l
+++ b/roseus/euslisp/actionlib.l
@@ -188,7 +188,7 @@
      ))
   (:wait-for-result
    (&key (timeout 0) ;; sec
-	 (return-if-server-down) (maximum-status-interval 5))
+         (return-if-server-down) (maximum-status-interval 5) (wait-rate 100))
    (let ((start (ros::time-now))
 	 (result-topic (format nil "~A/result" name-space)))
      (ros::ros-debug "[~A] :wait-for-result ~A, timeout=~A" name-space (if goal_id (send goal_id :id)) timeout)
@@ -196,9 +196,10 @@
        ;; https://github.com/ros/actionlib/blob/285c60265f18b683b1439accc9603c1e8be30a23/src/actionlib/simple_action_client.py#L128
        (ros::ros-error "[~A] :wait-for-result (return nil when no goal exists)" name-space)
        (return-from :wait-for-result nil))
-     (ros::rate 10)
+     (ros::rate wait-rate)
      (while (ros::ok)
        (ros::ros-debug "[~A] :wait-for-result ~A ~A" name-space (simple-goal-states-to-string simple-state) (send comm-state :state))
+       (send self :spin-once) ;; spin just before processing status
        (if (= simple-state ros::*simple-goal-state-done*)
 	   (return))
        (if (> timeout 0)
@@ -211,7 +212,6 @@
 	 (when (and status-stamp maximum-status-interval (> (send (ros::time- (ros::time-now) status-stamp) :to-sec) maximum-status-interval))
 	   (ros::ros-error "[~A] Unexpected returns from :wait-for-result : status did not received for 5 seconds" name-space)
 	   (return-from :wait-for-result nil)))
-       (send self :spin-once)
        (ros::sleep))
      (ros::ros-debug "[~A] :wait-for-result finished ~A" name-space (goal-status-to-string (send self :get-state)))
      (if (eq (send self :get-state) actionlib_msgs::GoalStatus::*preempted*)


### PR DESCRIPTION
wait-for-reault takes at least 0.1 sec and 0.2 sec at the worst.
https://github.com/start-jsk/rtmros_common/issues/1017

By current code, order of processing is processing-message, spin, wait. So, 'wait' always is on between getting message and processing message.
Then, changing the location of spinning and shortening waiting time can solve this problem.