### PR TITLE
roseus_mongo: fix decode escaped string

### DIFF
--- a/roseus_mongo/euslisp/json/json-decode.l
+++ b/roseus_mongo/euslisp/json/json-decode.l
@@ -64,6 +64,7 @@
         (return-from parse-string
           (get-output-stream-string os)))
        ((lisp::char= (peek-char is nil #\0) #\\) ;; #\0 is dummy
+        (read-char is) ;; skip
         (parse-escape-char is os))
        ((and (not (lisp::char= start-symbol #\"))
              (or (eq :eof (peek-char is nil :eof))

--- a/roseus_mongo/test/test-json-decode.l
+++ b/roseus_mongo/test/test-json-decode.l
@@ -49,8 +49,9 @@
                          (json::parse-string is))))
   (assert (string= "fuga" (json::parse-from-string "\"fuga\"")))
   (assert (string= "    fuga  " (json::parse-from-string "\"    fuga  \"")))
-  (assert (string= "\t\r\n\/\\ fuga" (json::parse-from-string "\"\t\r\n\/\\ fuga\"")))
+  (assert (string= "\t\r\n\/\\ fuga" (json::parse-from-string "\"\t\r\n\/\\\\ fuga\"")))
   (assert (string= "ほげ" (json::parse-from-string "\"ほげ\"")))
+  (assert (string= "{\"Samples\": [1]}" (json::parse-from-string "\"{\\\"Samples\\\": [1]}\"")))
   )
 
 (deftest test-json-decode-array ()


### PR DESCRIPTION
Fix for handling decoding json with escaped string values