### PR TITLE
package without msg does not have manifest.l, so skip loading that without  ros::ros-error

### DIFF
--- a/roseus/euslisp/roseus.l
+++ b/roseus/euslisp/roseus.l
@@ -358,14 +358,24 @@ always the rank of list is 2"
     (dolist (dir dirs)
       (if (probe-file (format nil "~A/~A/" dir pkg))
           (return-from ros::find-load-msg-path (format nil "~A/~A" dir pkg))))
+    ;; on jade/kinetic, package without msg does not have manifest.l
+    (let ((package-path (ros::rospack-find pkg)))
+      (if (not (or (probe-file (format nil "~A/msg" package-path))
+		   (probe-file (format nil "~A/srv" package-path))))
+	  (return-from ros::find-load-msg-path :no-msg-package)))
     (ros::ros-error "Could not find roseus messages for ~A under ~A~%try rosrun roseus generate-all-msg-srv.sh ~A" pkg dirs pkg)
     nil))
 
 (defun ros::load-ros-manifest (pkg)
-  (let ((manifest (format nil "~A/manifest.l" (ros::find-load-msg-path pkg))))
-    (if (probe-file manifest)
-	(load-org-for-ros manifest)
-      (ros::ros-error "Could not find ~A~%try rosrun roseus generate-all-msg-srv.sh ~A" manifest pkg))))
+  (let* ((msg-path (ros::find-load-msg-path pkg))
+	 (manifest (format nil "~A/manifest.l" msg-path)))
+    (cond ((eq msg-path :no-msg-package)
+	  ;; on jade/kinetic, package without msg does not have manifest.l
+	   (ros::ros-warn "Calling (load-ros-manifest ~A) for the package without msg/srv will be deprecated" pkg))
+	  ((probe-file manifest)
+	   (load-org-for-ros manifest))
+	  (t
+	   (ros::ros-error "Could not find ~A~%try rosrun roseus generate-all-msg-srv.sh ~A" manifest pkg)))))
 
 (defun ros::load-ros-package (pkg)
   "load reqruied roseus files for given package"

--- a/roseus/test/test-geneus.l
+++ b/roseus/test/test-geneus.l
@@ -6,6 +6,14 @@
 (require :unittest "lib/llib/unittest.l")
 
 (ros::load-ros-manifest "roseus")
+;; check if package without msgs is ok
+;; ros::eus-error is error
+(unless (fboundp 'ros::ros-error-org)
+  (setf (symbol-function 'ros::ros-error-org) (symbol-function 'ros::ros-error)))
+(defun ros::ros-error (&rest args)
+  (apply #'ros::ros-error-org args)
+  (error (apply #'format nil args)))
+(ros::load-ros-manifest "euslisp")
 
 ;;;
 ;;;


### PR DESCRIPTION
add test to check https://github.com/jsk-ros-pkg/jsk_roseus/pull/537 / https://github.com/jsk-ros-pkg/jsk_robot/issues/823 and rewrited  version of #357 
Closes jsk-ros-pkg/jsk_robot#823