### PR TITLE
Allow numbers on ros::roseus node name

### DIFF
--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -547,7 +547,7 @@ pointer ROSEUS(register context *ctx,int n,pointer *argv)
   } else error(E_NOSEQ);
 
   for (unsigned int i=0; i < strlen(name); i++)
-    if ( ! isalpha(name[i]) ) name[i] = '_';
+    if ( ! (isalpha(name[i]) || isdigit(name[i])) ) name[i] = '_';
 
   K_ROSEUS_MD5SUM   = defkeyword(ctx,"MD5SUM-");
   K_ROSEUS_DATATYPE = defkeyword(ctx,"DATATYPE-");

--- a/roseus/test/test-roseus.l
+++ b/roseus/test/test-roseus.l
@@ -26,9 +26,9 @@
   (ros::ros-info "get-uri ~A" (ros::get-uri))
   (ros::ros-info "get-topics ~A" (ros::get-topics))
 
-  (assert (equal (ros::get-nodes) '("/eusroseus" "/rosout"))) ;; test-roseus.test's test-name
-  (assert (equal (ros::get-uri) (format nil "http://~A:~A/" (ros::get-host) (ros::get-port))))
-  (assert (equal (ros::get-topics) '(("/rosout" . "rosgraph_msgs/Log") ("/rosout_agg" . "rosgraph_msgs/Log"))))
+  (assert (set-exclusive-or (ros::get-nodes) '("/eusroseus" "/rosout") :test #'equal)) ;; test-roseus.test's test-name
+  (assert (substringp (ros::get-uri) (format nil "http://~A:~A/" (ros::get-host) (ros::get-port))))
+  (assert (set-exclusive-or (ros::get-topics) '(("/rosout" . "rosgraph_msgs/Log") ("/rosout_agg" . "rosgraph_msgs/Log")) :test #'equal))
 
   )
 


### PR DESCRIPTION
Fix #536 

```
% roseus
(ros::roseus "test123-456" :anonymous nil)

% rosnode list
/rosout
/test123_456
```