### PR TITLE
Support both AcitonGoal and Goal in :send-goal

### DIFF
--- a/roseus/euslisp/actionlib.l
+++ b/roseus/euslisp/actionlib.l
@@ -164,6 +164,10 @@
   (:send-goal
    (goal &key done-cb active-cb feedback-cb)
    (let ((now (ros::time-now)))
+     ;; send-goal accepts both ActionGoal and Goal, where Python and C only takes Goal, but original roseus takes ActionGoal, here we make ActionGoal when Goal is passed as python/c client
+     (if (not (and (assoc 'ros::_goal_id (send goal :slots)) (assoc 'ros::_header (send goal :slots))))
+         (setq goal (send self :make-goal-instance goal)))
+     ;;
      (if (not (equal (send goal :goal_id :id) ""))
 	 (ros::ros-warn "goal_id's id is already set in goal instance. But :send-goal will overwrite")
        )

--- a/roseus/test/simple-client-test.l
+++ b/roseus/test/simple-client-test.l
@@ -62,6 +62,23 @@
     (send c :cancel-all-goals)
     ))
 
+(deftest test-simple-client-send-simple-goal ()
+  (let (c goal)
+    (setq c (instance ros::simple-action-client :init
+                      "reference_simple_action" actionlib::TestAction))
+    (warning-message 1 "wait-for-server~%")
+    (send c :wait-for-server)
+    (setq goal (instance actionlib::TestGoal :init))
+    (send goal :goal 1)
+    (send c :send-goal goal)
+    (warning-message 1 "wait-for-result~%")
+    (unless (send c :wait-for-result)
+      (warning-message 1 "Goal didn't finish (1: successed)~%")
+      (assert nil "The ref server did not returns result"))
+    (assert (equal (send c :get-state) actionlib_msgs::GoalStatus::*succeeded*))
+    (assert (string= (send c :get-goal-status-text)
+                          "The ref server has succeeded"))
+    ))
 (ros::roseus "simple_action_client")
 
 (run-all-tests)

--- a/roseus/test/simple-client-test.l
+++ b/roseus/test/simple-client-test.l
@@ -74,7 +74,7 @@
     (warning-message 1 "wait-for-result~%")
     (unless (send c :wait-for-result)
       (warning-message 1 "Goal didn't finish (1: successed)~%")
-      (assert nil "The ref server did not returns result"))
+      (assert nil "The ref server did not return result"))
     (assert (equal (send c :get-state) actionlib_msgs::GoalStatus::*succeeded*))
     (assert (string= (send c :get-goal-status-text)
                           "The ref server has succeeded"))

--- a/roseus/test/simple-client-test.l
+++ b/roseus/test/simple-client-test.l
@@ -26,7 +26,7 @@
     (warning-message 1 "wait-for-result~%")
     (unless (send c :wait-for-result)
       (warning-message 1 "Goal didn't finish (1: successed)~%")
-      (assert nil "The ref server did not returns result"))
+      (assert nil "The ref server did not return result"))
     (assert (equal (send c :get-state) actionlib_msgs::GoalStatus::*succeeded*))
     (assert (string= (send c :get-goal-status-text)
                           "The ref server has succeeded"))
@@ -55,7 +55,7 @@
                                              (ros::ros-info "Got Feedback")))
     (unless (send c :wait-for-result)
       (warning-message 1 "Goal didn't finish (9: feedback)~%")
-      (assert nil "The ref server did not returns result"))
+      (assert nil "The ref server did not return result"))
     (assert (equal (send c :get-state) actionlib_msgs::GoalStatus::*succeeded*))
     (assert (equal (send (elt saved-feedback 0) :feedback :feedback) 9))
 


### PR DESCRIPTION
see #543

actionlib.l:send-goal : send-goal accepts both ActionGoal and Goal, where
 Python and C only takes Goal, but original roseus takes ActoinGoal, here we
 make ActionGoal when Goal is passed as python/c client

send SimpleGoal, not SimpleActionGoal