### PR TITLE
test-roseus.l: test-master, ros::get-uri returns http://localhost:11311, not http://localhost:11311/, also accept arbitrary order in ros::get-nodes, ros::get-topics tests

### DIFF
--- a/roseus/test/test-anonymous.test
+++ b/roseus/test/test-anonymous.test
@@ -7,7 +7,7 @@
         required="true" />
   <param name="hztest1/topic" value="chatter" />  
   <param name="hztest1/hz" value="20.0" /> <!-- for two nodes -->
-  <param name="hztest1/hzerror" value="0.5" />
+  <param name="hztest1/hzerror" value="1.5" />
   <param name="hztest1/test_duration" value="5.0" />    
   <test test-name="test_anonymous" pkg="rostest" type="hztest"
         name="hztest1" />

--- a/roseus/test/test-roseus.l
+++ b/roseus/test/test-roseus.l
@@ -26,8 +26,11 @@
   (ros::ros-info "get-uri ~A" (ros::get-uri))
   (ros::ros-info "get-topics ~A" (ros::get-topics))
 
+  ;; order or (get-nodes) is not determined
   (assert (null (set-exclusive-or (ros::get-nodes) '("/eusroseus" "/rosout") :test #'equal))) ;; test-roseus.test's test-name
+  ;; setup.sh sets http://host:port but rostest sets http://host:port/, remove tailing /
   (assert (string= (string-right-trim "/" (ros::get-uri)) (format nil "http://~A:~A" (ros::get-host) (ros::get-port))))
+  ;; order or (get-topics) is not determined
   (assert (null (set-exclusive-or (ros::get-topics) '(("/rosout" . "rosgraph_msgs/Log") ("/rosout_agg" . "rosgraph_msgs/Log")) :test #'equal)))
 
   )

--- a/roseus/test/test-roseus.l
+++ b/roseus/test/test-roseus.l
@@ -26,9 +26,9 @@
   (ros::ros-info "get-uri ~A" (ros::get-uri))
   (ros::ros-info "get-topics ~A" (ros::get-topics))
 
-  (assert (equal (ros::get-nodes) '("/eusroseus" "/rosout"))) ;; test-roseus.test's test-name
-  (assert (equal (ros::get-uri) (format nil "http://~A:~A/" (ros::get-host) (ros::get-port))))
-  (assert (equal (ros::get-topics) '(("/rosout" . "rosgraph_msgs/Log") ("/rosout_agg" . "rosgraph_msgs/Log"))))
+  (assert (null (set-exclusive-or (ros::get-nodes) '("/eusroseus" "/rosout") :test #'equal))) ;; test-roseus.test's test-name
+  (assert (string= (string-right-trim "/" (ros::get-uri)) (format nil "http://~A:~A" (ros::get-host) (ros::get-port))))
+  (assert (null (set-exclusive-or (ros::get-topics) '(("/rosout" . "rosgraph_msgs/Log") ("/rosout_agg" . "rosgraph_msgs/Log")) :test #'equal)))
 
   )
 

--- a/roseus/test/test-roseus.l
+++ b/roseus/test/test-roseus.l
@@ -26,14 +26,19 @@
   (ros::ros-info "get-uri ~A" (ros::get-uri))
   (ros::ros-info "get-topics ~A" (ros::get-topics))
 
+  (format *error-output* "get-nodes : ~A~%" (ros::get-nodes))
+  (format *error-output* "get-uri : ~A, get-host : ~A, get-port : ~A~%" (ros::get-uri) (ros::get-host) (ros::get-port))
+  (format *error-output* "get-topics ~A~%~%" (ros::get-topics))
+
+  ;; from roslaunch 1.12.8 https://github.com/ros/ros_comm/issues/1097, rosout node is not launched
   ;; order or (get-nodes) is not determined
-  (assert (null (set-exclusive-or (ros::get-nodes) '("/eusroseus" "/rosout") :test #'equal))
+  (assert (member "/eusroseus" (ros::get-nodes) :test #'string=)
           "get-nodes : ~A" (ros::get-nodes)) ;; test-roseus.test's test-name
   ;; setup.sh sets http://host:port but rostest sets http://host:port/, remove tailing /
   (assert (string= (string-right-trim "/" (ros::get-uri)) (format nil "http://~A:~A" (ros::get-host) (ros::get-port)))
           "get-uri : ~A, get-host : ~A, get-port : ~A" (ros::get-uri) (ros::get-host) (ros::get-port))
   ;; order or (get-topics) is not determined
-  (assert (null (set-exclusive-or (ros::get-topics) '(("/rosout" . "rosgraph_msgs/Log") ("/rosout_agg" . "rosgraph_msgs/Log")) :test #'equal))
+  (assert (member '("/rosout" . "rosgraph_msgs/Log") (ros::get-topics) :test #'equal)
           "get-topics : ~A" (ros::get-topics))
 
   )

--- a/roseus/test/test-roseus.l
+++ b/roseus/test/test-roseus.l
@@ -27,11 +27,14 @@
   (ros::ros-info "get-topics ~A" (ros::get-topics))
 
   ;; order or (get-nodes) is not determined
-  (assert (null (set-exclusive-or (ros::get-nodes) '("/eusroseus" "/rosout") :test #'equal))) ;; test-roseus.test's test-name
+  (assert (null (set-exclusive-or (ros::get-nodes) '("/eusroseus" "/rosout") :test #'equal))
+          "get-nodes : ~A" (ros::get-nodes)) ;; test-roseus.test's test-name
   ;; setup.sh sets http://host:port but rostest sets http://host:port/, remove tailing /
-  (assert (string= (string-right-trim "/" (ros::get-uri)) (format nil "http://~A:~A" (ros::get-host) (ros::get-port))))
+  (assert (string= (string-right-trim "/" (ros::get-uri)) (format nil "http://~A:~A" (ros::get-host) (ros::get-port)))
+          "get-uri : ~A, get-host : ~A, get-port : ~A" (ros::get-uri) (ros::get-host) (ros::get-port))
   ;; order or (get-topics) is not determined
-  (assert (null (set-exclusive-or (ros::get-topics) '(("/rosout" . "rosgraph_msgs/Log") ("/rosout_agg" . "rosgraph_msgs/Log")) :test #'equal)))
+  (assert (null (set-exclusive-or (ros::get-topics) '(("/rosout" . "rosgraph_msgs/Log") ("/rosout_agg" . "rosgraph_msgs/Log")) :test #'equal))
+          "get-topics : ~A" (ros::get-topics))
 
   )
 


### PR DESCRIPTION
fix roseus test error, see https://github.com/jsk-ros-pkg/jsk_roseus/pull/545#issuecomment-349224047

```
Full test results for 'roseus/test_results/roseus/rosunit-eusroseus.xml'

-------------------------------------------------

<testsuite tests="5" failures="1" disabled="0" errors="0" time="25" name="AllTests">

  <testcase name="all-test" status="run" time="0" classname="all-test">

  </testcase>

  <testcase name="test-time" status="run" time="21" classname="test-time">

  </testcase>

  <testcase name="test-master" status="run" time="0" classname="test-master">

   <failure message="" type="AssertionError">

Test:(equal (ros::get-topics) '(("/rosout" . "rosgraph_msgs/Log") ("/rosout_agg" . "rosgraph_msgs/Log")))

Trace:"d/roseus/test_results/roseus/rosunit-eusroseus.xml

017  1.1.0))

Ã‡?).^[0m

.. ( ^[0mmstart testing [test-master]

s_jsk_roseus/buil"

Message:""

   </failure>

   <failure message="" type="AssertionError">

Test:(equal (ros::get-nodes) '("/eusroseus" "/rosout"))

Trace:"^[0mmstart testing [test-master]

s_jsk_roseus/build/roseus/test_results/roseus/rosunit-eusroseus.xml

017  1.1.0))

Ã‡?"

Message:""

   </failure>

  </testcase>

  <testcase name="test-marker-msg" status="run" time="0" classname="test-marker-msg">

  </testcase>

  <testcase name="resolve-path" status="run" time="0" classname="resolve-path">

  </testcase>

  <testcase name="test-image-conversion" status="run" time="4" classname="test-image-conversion">

  </testcase>

</testsuite>
```