### PR TITLE
do not load manifest.l when we have source tree, but does not have manifest.l because of missing msg/srv

### DIFF
--- a/roseus/euslisp/roseus.l
+++ b/roseus/euslisp/roseus.l
@@ -354,14 +354,17 @@ always the rank of list is 2"
       (setq dirs (nconc dirs (list (format nil "~A/share" (subseq ppath s i)))))
       (setq s (1+ i)))
     (setq dirs (nconc dirs (list (format nil "~A/share" (subseq ppath s)))))
+    ;;
+    ;; INDIGO: https://github.com/jsk-ros-pkg/jsk_roseus/issues/554
+    ;;          if pkg without msg, need to return no-msg-package
+    ;; JADE/KINETIC: https://github.com/jsk-ros-pkg/jsk_robot/issues/823
+    ;;          package without msg does not have manifest.l
     (dolist (dir dirs)
+      (if (and (probe-file (format nil "~A/~A/" dir pkg)) ;; package is in source tree
+	       (not (probe-file (format nil "~A/roseus/ros/~A/" dir pkg)))) ;; but does not have manifest.l
+	  (return-from ros::find-load-msg-path :no-msg-package))
       (if (probe-file (format nil "~A/roseus/ros/~A/" dir pkg))
 	  (return-from ros::find-load-msg-path (format nil "~A/roseus/ros/~A" dir pkg))))
-    ;; on jade/kinetic, package without msg does not have manifest.l
-    (let ((package-path (ros::rospack-find pkg)))
-      (if (not (or (probe-file (format nil "~A/msg" package-path))
-		   (probe-file (format nil "~A/srv" package-path))))
-	  (return-from ros::find-load-msg-path :no-msg-package)))
     (ros::ros-error "Could not find roseus messages for ~A under ~A~%try rosrun roseus generate-all-msg-srv.sh ~A" pkg dirs pkg)
     nil))
 

--- a/roseus/euslisp/roseus.l
+++ b/roseus/euslisp/roseus.l
@@ -374,11 +374,14 @@ always the rank of list is 2"
   (let* ((msg-path (ros::find-load-msg-path pkg))
 	 (manifest (format nil "~A/manifest.l" msg-path)))
     (cond ((eq msg-path :no-msg-package)
-	  ;; on jade/kinetic, package without msg does not have manifest.l
+           ;; on jade/kinetic, package without msg does not have manifest.l
 	   (ros::ros-warn "Calling (load-ros-manifest ~A) for the package without msg/srv will be deprecated" pkg)
 	   (ros::ros-warn "ACTION REQUIRED")
 	   (ros::ros-warn " Use (load-ros-{package,msg,srv} pkg) for the dependent packages with msg/srv" pkg)
-	   (ros::ros-warn " See https://github.com/jsk-ros-pkg/jsk_robot/issues/823"))
+	   (ros::ros-warn " See https://github.com/jsk-ros-pkg/jsk_robot/issues/823")
+           (dolist (dep (ros::rospack-depends pkg))
+             (ros::load-ros-package dep))
+           )
 	  ((probe-file manifest)
 	   (ros::ros-debug "Loading ~A" manifest)
 	   (load-org-for-ros manifest))

--- a/roseus/euslisp/roseus.l
+++ b/roseus/euslisp/roseus.l
@@ -361,7 +361,8 @@ always the rank of list is 2"
     ;; JADE/KINETIC: https://github.com/jsk-ros-pkg/jsk_robot/issues/823
     ;;          package without msg does not have manifest.l
     (dolist (dir dirs)
-      (if (and (probe-file (format nil "~A/~A/" dir pkg)) ;; package is in source tree
+      (if (and (not (string= pkg "roseus"))
+	       (probe-file (format nil "~A/~A/" dir pkg)) ;; package is in source tree
 	       (not (probe-file (format nil "~A/roseus/ros/~A/" dir pkg)))) ;; but does not have manifest.l
 	  (return-from ros::find-load-msg-path :no-msg-package))
       (if (probe-file (format nil "~A/roseus/ros/~A/" dir pkg))

--- a/roseus/euslisp/roseus.l
+++ b/roseus/euslisp/roseus.l
@@ -351,13 +351,12 @@ always the rank of list is 2"
         (ppath (unix::getenv "CMAKE_PREFIX_PATH"))
         (s 0) i)
     (while (setq i (position #\: ppath :start s))
-      (setq dirs (nconc dirs (list (format nil "~A/share/roseus/ros" (subseq ppath s i)))))
+      (setq dirs (nconc dirs (list (format nil "~A/share" (subseq ppath s i)))))
       (setq s (1+ i)))
-    (setq dirs (nconc dirs (list (format nil "~A/share/roseus/ros" (subseq ppath s)))))
-    ;;
+    (setq dirs (nconc dirs (list (format nil "~A/share" (subseq ppath s)))))
     (dolist (dir dirs)
-      (if (probe-file (format nil "~A/~A/" dir pkg))
-          (return-from ros::find-load-msg-path (format nil "~A/~A" dir pkg))))
+      (if (probe-file (format nil "~A/roseus/ros/~A/" dir pkg))
+	  (return-from ros::find-load-msg-path (format nil "~A/roseus/ros/~A" dir pkg))))
     ;; on jade/kinetic, package without msg does not have manifest.l
     (let ((package-path (ros::rospack-find pkg)))
       (if (not (or (probe-file (format nil "~A/msg" package-path))

--- a/roseus/euslisp/roseus.l
+++ b/roseus/euslisp/roseus.l
@@ -180,6 +180,7 @@
       (warning-message
        1 (format nil ";; can not find ~A directory for [~A] packages~%" dir pkg))
       (exit 1))
+    (ros::ros-debug "Loading ~A" dir)
     (unless (find-package (string-upcase pkg))
       (make-package (string-upcase pkg)))
     (dolist (file (directory dir))
@@ -373,8 +374,12 @@ always the rank of list is 2"
 	 (manifest (format nil "~A/manifest.l" msg-path)))
     (cond ((eq msg-path :no-msg-package)
 	  ;; on jade/kinetic, package without msg does not have manifest.l
-	   (ros::ros-warn "Calling (load-ros-manifest ~A) for the package without msg/srv will be deprecated" pkg))
+	   (ros::ros-warn "Calling (load-ros-manifest ~A) for the package without msg/srv will be deprecated" pkg)
+	   (ros::ros-warn "ACTION REQUIRED")
+	   (ros::ros-warn " Use (load-ros-{package,msg,srv} pkg) for the dependent packages with msg/srv" pkg)
+	   (ros::ros-warn " See https://github.com/jsk-ros-pkg/jsk_robot/issues/823"))
 	  ((probe-file manifest)
+	   (ros::ros-debug "Loading ~A" manifest)
 	   (load-org-for-ros manifest))
 	  (t
 	   (ros::ros-error "Could not find ~A~%try rosrun roseus generate-all-msg-srv.sh ~A" manifest pkg)))))


### PR DESCRIPTION
Closes #554 

package does not have msg/srv does not have manifest.l under `share/roseus/ros/<pkg>` but exists `share/<pkg>`,
previous logic skips this situation and load manifest.l from `/opt/ros/indigo/share/roseus/ros/<pkg>`

Fixed log to check if we have `share/<pkg>` but does not have `share/roseus/ros/<pkg>`, returns `:no-msg-packages`

c.f. https://github.com/jsk-ros-pkg/jsk_robot/issues/823 