### PR TITLE
[eustf.l] Fixed ros::tf-transform->coords

### DIFF
--- a/roseus/euslisp/eustf.l
+++ b/roseus/euslisp/eustf.l
@@ -105,6 +105,11 @@
 
 (defun ros::tf-transform->coords (trans)
   "Convert geoometry_msgs::Transform to euslisp coordinates"
+  (make-coords :pos (ros::tf-point->pos (send trans :translation))
+               :rot (ros::tf-quaternion->rot (send trans :rotation))))
+
+(defun ros::tf-transform-stamped->coords (trans)
+  "Convert geoometry_msgs::TransformStamped to euslisp coordinates"
   (instance tf-cascaded-coords
             :init
             :pos (ros::tf-point->pos (send trans :transform :translation))
@@ -112,10 +117,6 @@
             :frame-id (send trans :header :frame_id)
             :child-frame-id (send trans :child_frame_id)
             :stamp (send (send trans :header :stamp) :sec-nsec)))
-
-(defun ros::tf-transform-stamped->coords (trans)
-  "Convert geoometry_msgs::TransformStamped to euslisp coordinates"
-  (ros::tf-transform->coords trans))
 
 (defun ros::tf-twist->coords (twist)
   "Convert geoometry_msgs::Twist to euslisp coordinates"

--- a/roseus/euslisp/eustf.l
+++ b/roseus/euslisp/eustf.l
@@ -105,8 +105,10 @@
 
 (defun ros::tf-transform->coords (trans)
   "Convert geoometry_msgs::Transform to euslisp coordinates"
-  (make-coords :pos (ros::tf-point->pos (send trans :translation))
-               :rot (ros::tf-quaternion->rot (send trans :rotation))))
+  (instance tf-cascaded-coords
+            :init
+            :pos (ros::tf-point->pos (send trans :translation))
+            :rot (ros::tf-quaternion->rot (send trans :rotation))))
 
 (defun ros::tf-transform-stamped->coords (trans)
   "Convert geoometry_msgs::TransformStamped to euslisp coordinates"

--- a/roseus/test/test-tf.l
+++ b/roseus/test/test-tf.l
@@ -13,6 +13,10 @@
 (init-unit-test)
 
 (deftest test-common ()
+  (setq m (instance geometry_msgs::Transform :init))
+  (send m :transform :translation :y 5.0)
+  (send m :transform :rotation (ros::rot->tf-quaternion (unit-matrix 3)))
+  (setq c (ros::tf-transform->coords m))
   (setq m (instance geometry_msgs::TransformStamped :init))
   (send m :header :frame_id "PARENT")
   (send m :child_frame_id "THISFRAME")


### PR DESCRIPTION
In roseus, following error occured.
```
1.irteusgl$ ros::tf-transform->coords (instance geometry_msgs::Transform :init)
Call Stack (max depth: 20):
  0: at (send ros::trans :transform :translation)
  1: at (ros::tf-point->pos (send ros::trans :transform :translation))
  2: at (send #:inst342 :init :pos (ros::tf-point->pos (send ros::trans :transform :translation)) :rot (ros::tf-quaternion->rot (send ros::trans :transform :rotation)) :frame-id (send ros::trans :header :frame_id) :child-frame-id (send r\
os::trans :child_frame_id) :stamp (send (send ros::trans :header :stamp) :sec-nsec))
  3: at (let ((#:inst342 (instantiate ros::tf-cascaded-coords))) (send #:inst342 :init :pos (ros::tf-point->pos (send ros::trans :transform :translation)) :rot (ros::tf-quaternion->rot (send ros::trans :transform :rotation)) :frame-id (s\
end ros::trans :header :frame_id) :child-frame-id (send ros::trans :child_frame_id) :stamp (send (send ros::trans :header :stamp) :sec-nsec)) #:inst342)
  4: at (instance ros::tf-cascaded-coords :init :pos (ros::tf-point->pos (send ros::trans :transform :translation)) :rot (ros::tf-quaternion->rot (send ros::trans :transform :rotation)) :frame-id (send ros::trans :header :frame_id) :chil\
d-frame-id (send ros::trans :child_frame_id) :stamp (send (send ros::trans :header :stamp) :sec-nsec))
  5: at (ros::tf-transform->coords (instance transform :init))
  6: at #<compiled-code #X5621be8>
/home/leus/ros/indigo_parent/devel/share/euslisp/jskeus/eus/Linux64/bin/irteusgl 0 error: cannot find method :transform in (send ros::trans :transform :translation)
```

This PR fixed bug of ros::tf-transform->coords function.
Applying this PR, converting geoometry_msgs::Transform to euslisp coordinates works well.
```
6.irteusgl$ ros::tf-transform->coords (instance geometry_msgs::Transform :init)
;; quaternion2matrix : invalid input #f(0.0 0.0 0.0 0.0), the norm is not 1
#<coordinates #X5554190  0.0 0.0 0.0 / 0.0 0.0 0.0>
```

