### PR TITLE
Bugfixes and test codes for roseus_smach

### DIFF
--- a/roseus_smach/CMakeLists.txt
+++ b/roseus_smach/CMakeLists.txt
@@ -26,6 +26,8 @@ install(DIRECTORY sample src test
 if(CATKIN_ENABLE_TESTING)
   find_package(catkin REQUIRED COMPONENTS rostest)
   add_rostest(test/test_samples.test)
+  add_rostest(test/test_action_server.test)
+  add_rostest(test/test_action_client_state_in_server.test)
   add_rostest(test/test_roseus_smach_utils.test)
   add_rostest(test/test_async_join_state_machine_actionlib.test)
   add_rostest(test/test_parallel_state_machine_sample.test)

--- a/roseus_smach/sample/fibonacci-server.l
+++ b/roseus_smach/sample/fibonacci-server.l
@@ -5,16 +5,14 @@
 (load "package://roseus_smach/src/state-machine-actionlib.l")
 (ros::roseus-add-msgs "actionlib_tutorials")
 
-(ros::roseus "fibonacci")
-
 
 (defun func-fibonacci (userdata)
   (let* ((goal (cdr (assoc :goal userdata)))
-	 (result (cdr (assoc :result userdata)))
-	 (feedback (cdr (assoc :feedback userdata)))
-	 (cancel (cdr (assoc :cancel userdata)))
-	 (seq (send result :sequence)) (next 0))
-    (when (elt cancel 0) (return-from func-fibonacci))
+         (result (cdr (assoc :result userdata)))
+         (feedback (cdr (assoc :feedback userdata)))
+         (cancel (cdr (assoc :cancel userdata)))
+         (seq (send result :sequence)) (next 0))
+    (when cancel (return-from func-fibonacci))
     (when (/= (length seq) (send goal :order))
       (setq seq (make-array (send goal :order) :element-type :integer))
       (send result :sequence seq)
@@ -23,12 +21,12 @@
     (send feedback :sequence seq)
     (while t
       (cond ((eq next (send goal :order))
-	     (return-from func-fibonacci t))
-	    ((zerop (elt seq next))
-	     (setf (elt seq next) (+ (elt seq (- next 1))
-				     (elt seq (- next 2))))
-	     (return-from func-fibonacci nil))
-	    (t (incf next))))
+             (return-from func-fibonacci t))
+            ((zerop (elt seq next))
+             (setf (elt seq next) (+ (elt seq (- next 1))
+                                     (elt seq (- next 2))))
+             (return-from func-fibonacci nil))
+            (t (incf next))))
     ))
 (defun func-sleep (&rest args) (unix::sleep 1) t)
 
@@ -48,12 +46,17 @@
     (send sm :add-transition :SLEEP2 :CALC t)
     sm ))
 
-(warn "fibonacci server is working and press any key to stop.")
-(setq sm (fibonacci-smach))
-(setq s (instance state-machine-action-server :init "/fibonacci"
-		  actionlib_tutorials::fibonacciaction sm))
-(ros::rate 10)
-(do-until-key
- (ros::spin-once)
- (send s :worker)
- (ros::sleep))
+(defun run-fibonacci-server ()
+  (ros::roseus "fibonacci")
+  (warn "fibonacci server is working and press any key to stop.")
+  (setq sm (fibonacci-smach))
+  (setq s (instance state-machine-action-server :init "/fibonacci"
+                    actionlib_tutorials::fibonacciaction sm))
+  (ros::rate 10)
+  (do-until-key
+      (ros::spin-once)
+    (send s :worker)
+    (ros::sleep)))
+
+(when (substringp "__log:=" (car (last lisp::*eustop-argument*)))
+  (run-fibonacci-server))

--- a/roseus_smach/sample/fibonacci-server.l
+++ b/roseus_smach/sample/fibonacci-server.l
@@ -12,7 +12,7 @@
          (feedback (cdr (assoc :feedback userdata)))
          (cancel (cdr (assoc :cancel userdata)))
          (seq (send result :sequence)) (next 0))
-    (when cancel (return-from func-fibonacci))
+    (when (send cancel :enabled-p) (return-from func-fibonacci))
     (when (/= (length seq) (send goal :order))
       (setq seq (make-array (send goal :order) :element-type :integer))
       (send result :sequence seq)

--- a/roseus_smach/sample/state-machine-ros-sample.l
+++ b/roseus_smach/sample/state-machine-ros-sample.l
@@ -9,28 +9,29 @@
 
 (ros::roseus "smach_sample")
 
-;; sample for 
+;; sample for
 (ros::roseus-add-msgs "actionlib_tutorials")
 (load "package://roseus_smach/src/state-machine-actionlib.l")
-(defun smach-action-server ()
+(defun smach-action-client-state ()
   (let* ((client (instance ros::simple-action-client :init "/fibonacci" actionlib_tutorials::FibonacciAction))
-	 (sm (instance state-machine :init)))
-    (send sm :arg-keys :goal :cancel)
+         (sm (instance state-machine :init)))
+    (send sm :arg-keys :goal :cancel :result :feedback)
 
     (send sm :add-node
-	  (instance state :init :INITIAL
-		    '(lambda (arg)
-		       (let ((goal (instance actionlib_tutorials::FibonacciActionGoal :init)))
-			 (send goal :goal :order 10)
-			 (set-alist :goal goal arg))
-		       (print 'initialized) t)
-		    ))
+          (instance state :init :INITIAL
+                    '(lambda (arg)
+                      (let ((goal (instance actionlib_tutorials::FibonacciActionGoal :init)))
+                        (send goal :goal :order 10)
+                        (set-alist :goal goal arg))
+                      (print 'initialized) t)
+                    ))
     (send sm :add-node (actionlib-client-state :FIB client))
     (send sm :add-node
-	  (instance state :init :BAR
-		    '(lambda (arg)
-		       (print 'succeded) t)
-		    ))
+          (instance state :init :BAR
+                    '(lambda (arg)
+                      (warn "result: ~A~%" (cdr (assoc :result arg)))
+                      (print 'succeded) t)
+                    ))
     (send sm :start-state :INITIAL)
     (send sm :goal-state (list :SUCCEED-STATE :FAIL-STATE))
 

--- a/roseus_smach/sample/state-machine-sample.l
+++ b/roseus_smach/sample/state-machine-sample.l
@@ -69,6 +69,9 @@
 ;;
 (defun func-foo-data (args)
   (format t "Execute state FOO~%")
+  (unless (cdr (assoc 'foo-count args))
+    (warn "foo-count is not set. Setting 0~%")
+    (set-alist 'foo-count 0 args))
   (cond ((< (cdr (assoc 'foo-count args)) 3)
 	 (incf (cdr (assoc 'foo-count args))) :outcome1)
 	(t :outcome2)))

--- a/roseus_smach/src/state-machine-actionlib.l
+++ b/roseus_smach/src/state-machine-actionlib.l
@@ -8,7 +8,7 @@
     sm userdata successes inspector))
 (defmethod state-machine-action-server
   (:init
-   (ns spec &optional (_sm nil) (_userdata nil))
+   (ns spec &optional (_sm nil) (_userdata '(nil)))
    (setq as (instance ros::simple-action-server :init ns spec
           :execute-cb `(lambda(s g)(send ,self :execute-cb))
           :accept-cb  `(lambda(s g)(send ,self :accept-cb g))
@@ -27,37 +27,38 @@
   ;;
   (:accept-cb
    (msg)
-   (setq userdata (set-alist :cancel (vector nil) userdata))
    (set-alist :goal (send msg :goal) userdata)
    (set-alist :result (send (send as :result) :result) userdata)
    (set-alist :feedback (send (send as :feedback) :feedback) userdata)
    (send sm :reset-state))
   (:preempt-cb
    (msg)
-   (setf (elt (cdr (assoc :cancel userdata)) 0) t))
+   (set-alist :cancel t userdata))
   (:execute-cb
    ()
    (cond
-    ((null sm) nil)
-    ((send as :is-active)
-     (let ((result-msg (send as :result)))
-       (cond
-  ((send sm :goal-reached)
-   (send result-msg :result (cdr (assoc :result userdata)))
-   (if (member (send (send sm :active-state) :name) successes)
-       (send as :set-succeeded result-msg)
-     (send as :set-aborted result-msg)))
-  ((send as :is-preempt-requested)
-   (send as :set-preempted result-msg))
-  (t
-   (send inspector :publish-structure)
-   (send inspector :publish-status userdata)
-   (send sm :execute userdata :step -1)
-   (let ((feedback-msg (send as :feedback)))
-     (send feedback-msg :feedback (cdr (assoc :feedback userdata)))
-     (send as :publish-feedback feedback-msg)))
-  )))
-    (t nil)))
+     ((null sm) nil)
+     ((send as :is-active)
+      (let ((result-msg (send as :result)))
+        (cond
+          ((send sm :goal-reached)
+           (send result-msg :result (cdr (assoc :result userdata)))
+           (if (member (send (send sm :active-state) :name) successes)
+               (send as :set-succeeded result-msg)
+               (send as :set-aborted result-msg)))
+          ((send as :is-preempt-requested)
+           ;; send incomplete data as result
+           (send result-msg :result (cdr (assoc :result userdata)))
+           (send as :set-preempted result-msg))
+          (t
+           (send inspector :publish-structure)
+           (send inspector :publish-status userdata)
+           (send sm :execute userdata :step -1)
+           (let ((feedback-msg (send as :feedback)))
+             (send feedback-msg :feedback (cdr (assoc :feedback userdata)))
+             (send as :publish-feedback feedback-msg)))
+          )))
+     (t nil)))
   )
 
 ;;
@@ -67,52 +68,56 @@
 ;;   this state returns :succeeded or :failed
 ;;
 (defun actionlib-client-state
-  (name client
-   &key (timeout 10) (retry nil) (key #'identity) (return-success :succeeded) (return-fail :failed)
-        (async nil) (return-async t))
+    (name client
+     &key (timeout 10) (retry nil) (key #'identity) (return-success :succeeded) (return-fail :failed)
+       (async nil) (return-async t))
   (send client :wait-for-server)
   (instance state :init name
    ;; main loop
    `(lambda (userdata)
       (let ((start (ros::time-now)) async-clients)
-  (send ,client :send-goal
-        (funcall (quote ,key) (cdr (assoc :goal userdata))))
-  (if ,async
-    (progn
-      (setq async-clients (cdr (assoc :async userdata)))
-      (set-alist :async (flatten (list async-clients ,client)) userdata)
-     (ros::sleep)
-     (send ,client :spin-once)
-     ,return-async)
-  (while (ros::ok)
-    (ros::sleep)
-    (send ,client :spin-once)
-    ;;
-    (cond
-     ((eq (send ,client :get-state) actionlib_msgs::GoalStatus::*SUCCEEDED*)
-       (return ,return-success))
-      ((eq (send ,client :get-state) actionlib_msgs::GoalStatus::*ABORTED*)
-       (if ,retry
-     (send ,client :send-goal
-           (funcall (quote ,key) (cdr (assoc :goal userdata))))
-         (return ,return-fail)))
-      ((member (send ,client :get-state)
-         (list actionlib_msgs::GoalStatus::*PREEMPTED*
-         actionlib_msgs::GoalStatus::*RECALLED*
-         actionlib_msgs::GoalStatus::*REJECTED*))
-       (return ,return-fail))
-      ((member (send ,client :get-state)
-         (list actionlib_msgs::GoalStatus::*ACTIVE*
-          actionlib_msgs::GoalStatus::*PENDING*))
-       ;; user cancel
-       (if (and (vectorp (cdr (assoc :cancel userdata)))
-          (elt (cdr (assoc :cancel userdata)) 0))
-     (send ,client :cancel-goal))
-       ;; time out
-       (if (and (numberp ,timeout)
-          (< ,timeout (send (ros::time- (ros::time-now) start) :to-sec)))
-     (send ,client :cancel-goal))))
-    )))))
+        (send ,client :send-goal
+              (funcall (quote ,key) (cdr (assoc :goal userdata))))
+        (if ,async
+            (progn
+              (setq async-clients (cdr (assoc :async userdata)))
+              (set-alist :async (flatten (list async-clients ,client)) userdata)
+              (ros::sleep)
+              (send ,client :spin-once)
+              ,return-async) ;; async end
+            (while (ros::ok)
+              (ros::sleep)
+              (send ,client :spin-once)
+              ;;
+              (cond
+                ((eq (send ,client :get-state) actionlib_msgs::GoalStatus::*SUCCEEDED*)
+                 (set-alist :result (send ,client :get-result) userdata)
+                 (return ,return-success))
+                ((eq (send ,client :get-state) actionlib_msgs::GoalStatus::*ABORTED*)
+                 (if ,retry
+                     (send ,client :send-goal
+                           (funcall (quote ,key) (cdr (assoc :goal userdata))))
+                     (progn
+                       (set-alist :result (send ,client :get-result) userdata)
+                       (return ,return-fail))))
+                ((member (send ,client :get-state)
+                         (list actionlib_msgs::GoalStatus::*PREEMPTED*
+                               actionlib_msgs::GoalStatus::*RECALLED*
+                               actionlib_msgs::GoalStatus::*REJECTED*))
+                 (set-alist :cancel t userdata)
+                 (set-alist :result (send ,client :get-result) userdata)
+                 (return ,return-fail))
+                ((member (send ,client :get-state)
+                         (list actionlib_msgs::GoalStatus::*ACTIVE*
+                               actionlib_msgs::GoalStatus::*PENDING*))
+                 ;; user cancel
+                 (if (eq t (cdr (assoc :cancel userdata)))
+                     (send ,client :cancel-goal))
+                 ;; time out
+                 (if (and (numberp ,timeout)
+                          (< ,timeout (send (ros::time- (ros::time-now) start) :to-sec)))
+                     (send ,client :cancel-goal))))
+              )))))
   )
 
 ;; simple usage

--- a/roseus_smach/src/state-machine-actionlib.l
+++ b/roseus_smach/src/state-machine-actionlib.l
@@ -1,5 +1,19 @@
 (load "state-machine-ros.l")
 
+;; binary state object
+(defclass binary-state-object
+  :super propertied-object
+  :slots (enabled))
+(defmethod binary-state-object
+  (:init (&optional (initial-value nil))
+   (setq enabled (not (null initial-value))))
+  (:enable ()
+   (setq enabled t))
+  (:disable ()
+   (setq enabled nil))
+  (:enabled-p ()
+   enabled))
+
 ;; execute state machine as action server
 
 (defclass state-machine-action-server
@@ -27,13 +41,14 @@
   ;;
   (:accept-cb
    (msg)
+   (set-alist :cancel (instance binary-state-object :init) userdata)
    (set-alist :goal (send msg :goal) userdata)
    (set-alist :result (send (send as :result) :result) userdata)
    (set-alist :feedback (send (send as :feedback) :feedback) userdata)
    (send sm :reset-state))
   (:preempt-cb
    (msg)
-   (set-alist :cancel t userdata))
+   (send (cdr (assoc :cancel userdata)) :enable))
   (:execute-cb
    ()
    (cond
@@ -76,6 +91,9 @@
    ;; main loop
    `(lambda (userdata)
       (let ((start (ros::time-now)) async-clients)
+        (when (or (null (cdr (assoc :cancel userdata)))
+                  (not (derivedp (cdr (assoc :cancel userdata)) binary-state-object)))
+          (ros::ros-warn "userdata :cancel is empty or not binary-state-object. Cancellation may not work."))
         (send ,client :send-goal
               (funcall (quote ,key) (cdr (assoc :goal userdata))))
         (if ,async
@@ -87,6 +105,7 @@
               ,return-async) ;; async end
             (while (ros::ok)
               (ros::sleep)
+              (ros::spin-once) ;; spin to update user cancel state
               (send ,client :spin-once)
               ;;
               (cond
@@ -111,8 +130,10 @@
                          (list actionlib_msgs::GoalStatus::*ACTIVE*
                                actionlib_msgs::GoalStatus::*PENDING*))
                  ;; user cancel
-                 (if (eq t (cdr (assoc :cancel userdata)))
-                     (send ,client :cancel-goal))
+                 (when (and (cdr (assoc :cancel userdata))
+                            (derivedp (cdr (assoc :cancel userdata)) binary-state-object)
+                            (send (cdr (assoc :cancel userdata)) :enabled-p))
+                   (send ,client :cancel-goal))
                  ;; time out
                  (if (and (numberp ,timeout)
                           (< ,timeout (send (ros::time- (ros::time-now) start) :to-sec)))

--- a/roseus_smach/src/state-machine-actionlib.l
+++ b/roseus_smach/src/state-machine-actionlib.l
@@ -56,15 +56,17 @@
      ((send as :is-active)
       (let ((result-msg (send as :result)))
         (cond
+          ((send as :is-preempt-requested)
+           ;; send incomplete data as result
+           (ros::ros-info "Preempt requested")
+           (send result-msg :result (cdr (assoc :result userdata)))
+           (send as :set-preempted result-msg))
           ((send sm :goal-reached)
+           (ros::ros-debug "Goal reached")
            (send result-msg :result (cdr (assoc :result userdata)))
            (if (member (send (send sm :active-state) :name) successes)
                (send as :set-succeeded result-msg)
                (send as :set-aborted result-msg)))
-          ((send as :is-preempt-requested)
-           ;; send incomplete data as result
-           (send result-msg :result (cdr (assoc :result userdata)))
-           (send as :set-preempted result-msg))
           (t
            (send inspector :publish-structure)
            (send inspector :publish-status userdata)
@@ -90,7 +92,7 @@
   (instance state :init name
    ;; main loop
    `(lambda (userdata)
-      (let ((start (ros::time-now)) async-clients)
+      (let ((start (ros::time-now)) async-clients (last-warn (ros::time 0)))
         (when (or (null (cdr (assoc :cancel userdata)))
                   (not (derivedp (cdr (assoc :cancel userdata)) binary-state-object)))
           (ros::ros-warn "userdata :cancel is empty or not binary-state-object. Cancellation may not work."))
@@ -123,9 +125,16 @@
                          (list actionlib_msgs::GoalStatus::*PREEMPTED*
                                actionlib_msgs::GoalStatus::*RECALLED*
                                actionlib_msgs::GoalStatus::*REJECTED*))
+                 (ros::ros-info "~A was canceled" (send ,client :name))
                  (set-alist :cancel t userdata)
                  (set-alist :result (send ,client :get-result) userdata)
                  (return ,return-fail))
+                ((member (send ,client :get-state)
+                         (list actionlib_msgs::GoalStatus::*PREEMPTING*
+                               actionlib_msgs::GoalStatus::*RECALLING*))
+                 (when (> (send (ros::time- (ros::time-now) last-warn) :to-sec) 1.0)
+                   (ros::ros-info "Waiting for cancellation of ~A" (send ,client :name))
+                   (setq last-warn (ros::time-now))))
                 ((member (send ,client :get-state)
                          (list actionlib_msgs::GoalStatus::*ACTIVE*
                                actionlib_msgs::GoalStatus::*PENDING*))
@@ -133,10 +142,12 @@
                  (when (and (cdr (assoc :cancel userdata))
                             (derivedp (cdr (assoc :cancel userdata)) binary-state-object)
                             (send (cdr (assoc :cancel userdata)) :enabled-p))
+                   (ros::ros-info "Sending cancel to ~A" (send ,client :name))
                    (send ,client :cancel-goal))
                  ;; time out
-                 (if (and (numberp ,timeout)
-                          (< ,timeout (send (ros::time- (ros::time-now) start) :to-sec)))
+                 (when (and (numberp ,timeout)
+                            (< ,timeout (send (ros::time- (ros::time-now) start) :to-sec)))
+                     (ros::ros-info "Timed out. Sending cancel to ~A" (send ,client :name))
                      (send ,client :cancel-goal))))
               )))))
   )

--- a/roseus_smach/src/state-machine-utils.l
+++ b/roseus_smach/src/state-machine-utils.l
@@ -1,6 +1,6 @@
 ;; state-machine-utils.l
 
-(defun exec-state-machine (sm &optional mydata
+(defun exec-state-machine (sm &optional (mydata '(nil))
                            &key (spin t) (hz 1) (root-name "SM_ROOT") iterate)
   "Execute state machine
 

--- a/roseus_smach/src/state-machine.l
+++ b/roseus_smach/src/state-machine.l
@@ -186,7 +186,7 @@
   (:remap (userdata &key (invert nil))
    (dolist (ft remap-list)
      (when (and (not invert) (not (assoc (cdr ft) userdata)))
-       (nconc (list (cons (cdr ft) nil)) userdata))
+       (nconc userdata (list (cons (cdr ft) nil))))
      (if invert
          (setf (car (assoc (car ft) userdata)) (cdr ft))
          (setf (car (assoc (cdr ft) userdata)) (car ft)))))

--- a/roseus_smach/test/smach-action-client-state-in-server.l
+++ b/roseus_smach/test/smach-action-client-state-in-server.l
@@ -1,0 +1,21 @@
+#!/usr/bin/env roseus
+;; smach-action-client-state-in-server.l
+;; Author:  <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+
+(ros::roseus-add-msgs "actionlib_tutorials")
+(load "package://roseus_smach/sample/state-machine-ros-sample.l")
+
+(ros::roseus "fibonacci_test")
+
+(setq *sm* (smach-action-client-state))
+(send *sm* :arg-keys :goal :cancel :result :feedback)
+(setq *as* (instance state-machine-action-server :init
+                     "/fibonacci_test" actionlib_tutorials::fibonacciaction
+                     *sm*))
+(send *as* :success-state '(:SUCCEED-STATE))
+
+(while (ros::ok)
+  (send *as* :worker)
+  (ros::spin-once)
+  (ros::sleep))
+(exit)

--- a/roseus_smach/test/test-action-client-state-in-server.l
+++ b/roseus_smach/test/test-action-client-state-in-server.l
@@ -1,0 +1,71 @@
+#!/usr/bin/env roseus
+;; test-smach-action-server.l
+;; Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+
+(ros::roseus-add-msgs "actionlib_tutorials")
+
+(require :unittest "lib/llib/unittest.l")
+
+(ros::roseus "test_smach_action_server")
+
+(init-unit-test)
+
+(deftest test-action-client-state-in-server ()
+  (setq *ac* (instance ros::simple-action-client :init
+                       "/fibonacci_test"
+                       actionlib_tutorials::fibonacciaction))
+  (assert (send *ac* :wait-for-server 10)
+          "/fibonnaci_test action is initialized")
+
+  (let ((goal (instance actionlib_tutorials::fibonacciactiongoal :init)))
+    (send goal :goal :order 5)
+    (send *ac* :send-goal goal))
+  (unix:sleep 1)
+  (send *ac* :spin-once)
+  (assert (eq (send *ac* :get-state)
+              actionlib_msgs::GoalStatus::*active*)
+          "/fibonacci_test action is active")
+  (assert (send *ac* :wait-for-result :timeout 30)
+          "/fibonacci_test action wait-for-result returns t")
+  (warning-message 2 "get-state: ~A~%" (send *ac* :get-state))
+  (assert (eq (send *ac* :get-state)
+              actionlib_msgs::GoalStatus::*succeeded*)
+          "/fibonacci_test action state is *succeeded*")
+  (print-ros-msg (send *ac* :get-result))
+  (assert (and (send (send *ac* :get-result) :sequence)
+          "/fibonacci_test action returns result")))
+
+(deftest test-smach-action-server-cancel ()
+  (setq *ac* (instance ros::simple-action-client :init
+                       "/fibonacci_test"
+                       actionlib_tutorials::fibonacciaction))
+  (assert (send *ac* :wait-for-server 10)
+          "/fibonnaci_test action is initialized")
+
+  (let ((goal (instance actionlib_tutorials::fibonacciactiongoal :init)))
+    (send goal :goal :order 30)
+    (send *ac* :send-goal goal))
+  (unix:sleep 1)
+  (send *ac* :spin-once)
+  (assert (eq (send *ac* :get-state)
+              actionlib_msgs::GoalStatus::*active*)
+          "/fibonacci_test action is active")
+
+  (unix:sleep 3)
+  (send *ac* :cancel-goal)
+  (send *ac* :wait-for-result :timeout 30)
+  (send *ac* :spin-once)
+  (warning-message 2 "get-state: ~A~%" (send *ac* :get-state))
+  (assert (memq (send *ac* :get-state)
+                (list actionlib_msgs::GoalStatus::*preempted*
+                      actionlib_msgs::GoalStatus::*preempting*))
+          (format nil "/fibonacci_test action state ~A is *preempted* or *preempting*"
+           (send *ac* :get-state)))
+  (print-ros-msg (send *ac* :get-result))
+  (assert (> (length (send (send *ac* :get-result) :sequence)) 0)
+          "/fibonnaci_test action returns result")
+  )
+
+
+(run-all-tests)
+(exit)

--- a/roseus_smach/test/test-action-client-state-in-server.l
+++ b/roseus_smach/test/test-action-client-state-in-server.l
@@ -53,16 +53,20 @@
 
   (unix:sleep 3)
   (send *ac* :cancel-goal)
+  (warning-message 2 ":cancel-goal is sent~%")
   (send *ac* :wait-for-result :timeout 30)
   (send *ac* :spin-once)
   (warning-message 2 "get-state: ~A~%" (send *ac* :get-state))
+  ;; see http://wiki.ros.org/actionlib/DetailedDescription
   (assert (memq (send *ac* :get-state)
-                (list actionlib_msgs::GoalStatus::*preempted*
-                      actionlib_msgs::GoalStatus::*preempting*))
+                (list
+                 actionlib_msgs::GoalStatus::*aborted*
+                 actionlib_msgs::GoalStatus::*preempted*
+                 actionlib_msgs::GoalStatus::*preempting*))
           (format nil "/fibonacci_test action state ~A is *preempted* or *preempting*"
            (send *ac* :get-state)))
   (print-ros-msg (send *ac* :get-result))
-  (assert (> (length (send (send *ac* :get-result) :sequence)) 0)
+  (assert (integer-vector-p (send (send *ac* :get-result) :sequence))
           "/fibonnaci_test action returns result")
   )
 

--- a/roseus_smach/test/test-action-server.l
+++ b/roseus_smach/test/test-action-server.l
@@ -1,0 +1,68 @@
+#!/usr/bin/env roseus
+;; test-action-server.l
+;; Author: Yuki Furuta <furushchev@jsk.imi.i.u-tokyo.ac.jp>
+
+(ros::roseus-add-msgs "actionlib_tutorials")
+
+(require :unittest "lib/llib/unittest.l")
+
+(ros::roseus "test_action_server")
+
+(init-unit-test)
+
+(deftest test-smach-action-server ()
+  (setq *ac* (instance ros::simple-action-client :init
+                       "fibonacci"
+                       actionlib_tutorials::fibonacciaction))
+  (assert (send *ac* :wait-for-server 10)
+          "/fibonnaci action is initialized")
+
+  (let ((goal (instance actionlib_tutorials::fibonacciactiongoal :init)))
+    (send goal :goal :order 5)
+    (send *ac* :send-goal goal))
+  (unix:sleep 1)
+  (send *ac* :spin-once)
+  (assert (eq (send *ac* :get-state)
+              actionlib_msgs::GoalStatus::*active*)
+          "/fibonacci action is active")
+  (assert (send *ac* :wait-for-result :timeout 30)
+          "/fibonacci action wait-for-result returns t")
+  (warning-message 2 "get-state: ~A~%" (send *ac* :get-state))
+  (assert (eq (send *ac* :get-state)
+              actionlib_msgs::GoalStatus::*succeeded*)
+          "/fibonacci action state is *succeeded*")
+  (assert (and (send (send *ac* :get-result) :sequence)
+          "/fibonnaci action returns result")))
+
+(deftest test-smach-action-server-cancel ()
+  (setq *ac* (instance ros::simple-action-client :init
+                       "fibonacci"
+                       actionlib_tutorials::fibonacciaction))
+  (assert (send *ac* :wait-for-server 10)
+          "/fibonnaci action is initialized")
+
+  (let ((goal (instance actionlib_tutorials::fibonacciactiongoal :init)))
+    (send goal :goal :order 30)
+    (send *ac* :send-goal goal))
+  (unix:sleep 1)
+  (send *ac* :spin-once)
+  (assert (eq (send *ac* :get-state)
+              actionlib_msgs::GoalStatus::*active*)
+          "/fibonacci action is active")
+
+  (unix:sleep 3)
+  (send *ac* :cancel-goal)
+  (send *ac* :wait-for-result :timeout 30)
+  (send *ac* :spin-once)
+  (warning-message 2 "get-state: ~A~%" (send *ac* :get-state))
+  (assert (memq (send *ac* :get-state)
+                (list actionlib_msgs::GoalStatus::*preempted*
+                      actionlib_msgs::GoalStatus::*preempting*))
+          "/fibonacci action state is *preempting* or *preempted*")
+  (print-ros-msg (send *ac* :get-result))
+  (assert (> (length (send (send *ac* :get-result) :sequence)) 0)
+          "/fibonnaci action returns result")
+  )
+
+(run-all-tests)
+(exit)

--- a/roseus_smach/test/test-samples.l
+++ b/roseus_smach/test/test-samples.l
@@ -6,17 +6,27 @@
 
 (init-unit-test)
 
-(deftest test-smach-sample-simple
+(deftest test-smach-sample-simple ()
   (assert (eq (send (exec-smach-simple) :name) :outcome4)
 	  "simple smach sample"))
 
-(deftest test-smach-sample-nested
+(deftest test-smach-sample-nested ()
   (assert (eq (send (exec-smach-nested) :name) :outcome5)
 	  "nested smach sample"))
 
-(deftest test-smach-sample-userdata
+(deftest test-smach-sample-userdata ()
   (assert (eq (send (exec-smach-userdata) :name) :outcome4)
-	  "sample of smach with userdata"))
+	  "sample of smach with userdata")
+  (assert (eq (send (exec-state-machine (smach-userdata)) :name) :outcome4)
+          "exec (smach-userdata) without initial userdata"))
+
+(deftest test-smach-action-client-state ()
+  (setq userdata '(nil))
+  (assert (eq (send (exec-state-machine (smach-action-client-state) userdata) :name) :SUCCEED-STATE)
+          "exec (smach-action-server) is succeeded")
+  (assert (cdr (assoc :result userdata))
+          "action-client-state sets action result to userdata for key :result"))
+
 
 (run-all-tests)
 

--- a/roseus_smach/test/test_action_client_state_in_server.test
+++ b/roseus_smach/test/test_action_client_state_in_server.test
@@ -1,6 +1,8 @@
 <launch>
-  <node name="fibonacci" pkg="actionlib_tutorials" type="fibonacci_server"/>
-  <node name="fibonacci_test" pkg="roseus_smach" type="smach-action-client-state-in-server.l"/>
+  <node name="fibonacci" pkg="actionlib_tutorials" type="fibonacci_server"
+        output="screen"/>
+  <node name="fibonacci_test" pkg="roseus_smach" type="smach-action-client-state-in-server.l"
+        output="screen"/>
   <test test-name="test_action_client_state_in_server"
         pkg="roseus_smach" type="test-action-client-state-in-server.l"/>
 </launch>

--- a/roseus_smach/test/test_action_client_state_in_server.test
+++ b/roseus_smach/test/test_action_client_state_in_server.test
@@ -1,0 +1,6 @@
+<launch>
+  <node name="fibonacci" pkg="actionlib_tutorials" type="fibonacci_server"/>
+  <node name="fibonacci_test" pkg="roseus_smach" type="smach-action-client-state-in-server.l"/>
+  <test test-name="test_action_client_state_in_server"
+        pkg="roseus_smach" type="test-action-client-state-in-server.l"/>
+</launch>

--- a/roseus_smach/test/test_action_server.test
+++ b/roseus_smach/test/test_action_server.test
@@ -1,0 +1,7 @@
+<launch>
+  <node name="fibonacci" pkg="roseus_smach" type="fibonacci-server.l"
+        output="screen"/>
+
+  <test test-name="test_action_server"
+        pkg="roseus_smach" type="test-action-server.l"/>
+</launch>

--- a/roseus_smach/test/test_samples.test
+++ b/roseus_smach/test/test_samples.test
@@ -1,4 +1,5 @@
 <launch>
+  <node name="fibonacci_server" pkg="actionlib_tutorials" type="fibonacci_server"/>
   <test test-name="test_roseus_smach_samples" pkg="roseus" type="roseus"
         args="$(find roseus_smach)/test/test-samples.l" />
 </launch>


### PR DESCRIPTION
rewrite #558

- Fix: indentations
- Fix: [bug] values set as userdata are completely lost if not given as arguments
- Fix: weird vector value set to :cancel for userdata in state-machine-action-server
- Add: Test code for action-client-state / state-machine-action-server class
- Add: action-client-state sets action result/feedback to userdata for key :result/:feedback