### PR TITLE
[roseus.l] add length check for argument when searching __log:=

### DIFF
--- a/roseus/euslisp/roseus.l
+++ b/roseus/euslisp/roseus.l
@@ -27,7 +27,8 @@
    (exit 1))
 
 ;; check if this process is created by roslaunch
-(when (string= "__log:=" (subseq (car (last lisp::*eustop-argument*)) 0 7))
+(when (let ((arg (car (last lisp::*eustop-argument*))))
+        (and (>= (length arg) 7) (string= "__log:=" (subseq arg 0 7))))
   (ros::ROS-INFO "install ros::roseus-sigint-handler")
   (setq lisp::*exit-on-fatal-error* t)
   (lisp::install-error-handler 'ros::roseus-error)


### PR DESCRIPTION
if the last argument is shorter than 7,  error occurs .

~~~
Call Stack (max depth: 20):
  0: at (subseq (car (last lisp::*eustop-argument*)) 0 7)
  1: at (string= "__log:=" (subseq (car (last lisp::*eustop-argument*)) 0 7))
  2: at (if (string= "__log:=" (subseq (car (last lisp::*eustop-argument*)) 0 7)) (progn (ros-info "install ros::roseus-sigint-handler") (setq *exit-on-fatal-error* t) (lisp::install-error-handler 'roseus-error) (unix:signal unix::sigint 'roseus-sigint-handler) (unix:signal unix::sighup 'roseus-sigint-handler) (defmacro user::do-until-key (&rest forms) (cons 'while (cons 't (append forms nil)))) (defun y-or-n-p (&rest args) t)))
  3: at (when (string= "__log:=" (subseq (car (last lisp::*eustop-argument*)) 0 7)) (ros-info "install ros::roseus-sigint-handler") (setq *exit-on-fatal-error* t) (lisp::install-error-handler 'roseus-error) (unix:signal unix::sigint 'roseus-sigint-handler) (unix:signal unix::sighup 'roseus-sigint-handler) (defmacro user::do-until-key (&rest forms) (cons 'while (cons 't (append forms nil)))) (defun y-or-n-p (&rest args) t))
/home/leus/ros/devel/share/euslisp/jskeus/eus/Linux64/bin/irteusgl: ERROR th=0 illegal start/end index  in (subseq (car (last lisp::*eustop-argument*)) 0 7)
~~~