### PR TITLE
check why test-smach-action-client-state failing on installed test

### DIFF
--- a/roseus_smach/test/test-samples.l
+++ b/roseus_smach/test/test-samples.l
@@ -20,22 +20,12 @@
   (assert (eq (send (exec-state-machine (smach-userdata)) :name) :outcome4)
           "exec (smach-userdata) without initial userdata"))
 
-#|
-;; removed since it is always failling on only installed test https://api.travis-ci.org/v3/job/406576370/log.txt
-;; not sure why...
-;;   start testing [test-smach-action-client-state]
-;;   m;p=pointer?(0x6252338)
-;;   ;; Segmentation Fault.
-;;   terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >'
-;;   what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
-;;
 (deftest test-smach-action-client-state ()
   (setq userdata '(nil))
   (assert (eq (send (exec-state-machine (smach-action-client-state) userdata) :name) :SUCCEED-STATE)
           "exec (smach-action-server) is succeeded")
   (assert (cdr (assoc :result userdata))
           "action-client-state sets action result to userdata for key :result"))
-|#
 
 (run-all-tests)
 


### PR DESCRIPTION
re-enable test removed in #567 

```
;; removed since it is always failling on only installed test https://api.travis-ci.org/v3/job/406576370/log.txt
;; not sure why...
;;   start testing [test-smach-action-client-state]
;;   m;p=pointer?(0x6252338)
;;   ;; Segmentation Fault.
;;   terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >'
;;   what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
```
c.f. https://github.com/jsk-ros-pkg/jsk_roseus/pull/567#issuecomment-406841511
