### PR TITLE
use PROJECT_SOURCE_DIR instaed of CMAKE_SOURCE_DIR for `catkin_make`

### DIFF
--- a/roseus/CMakeLists.txt
+++ b/roseus/CMakeLists.txt
@@ -94,7 +94,7 @@ endif()
 # you need to run `catkin build --force-cmake` when you have updated eus.h
 # update function using defun() for https://github.com/euslisp/EusLisp/pull/116
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/test-defun.c "#include \"eus.h\"\nvoid TEST();\nvoid test(void) {register context *ctx; pointer mod; defun(ctx,\"TEST\",mod,TEST,NULL);}")
-get_directory_property(__CMAKE_COMPILE_DEFINITIONS DIRECTORY ${CMAKE_SOURCE_DIR} COMPILE_DEFINITIONS)
+get_directory_property(__CMAKE_COMPILE_DEFINITIONS DIRECTORY ${PROJECT_SOURCE_DIR} COMPILE_DEFINITIONS)
 set(__CMAKE_COMPILE_DEFINITION "")
 foreach(__D ${__CMAKE_COMPILE_DEFINITIONS})
   set(__CMAKE_COMPILE_DEFINITION ${__CMAKE_COMPILE_DEFINITION} -D${__D})

--- a/roseus/CMakeLists.txt
+++ b/roseus/CMakeLists.txt
@@ -100,6 +100,8 @@ foreach(__D ${__CMAKE_COMPILE_DEFINITIONS})
   set(__CMAKE_COMPILE_DEFINITION ${__CMAKE_COMPILE_DEFINITION} -D${__D})
 endforeach()
 message(STATUS "Running test file to check defun() API, see https://github.com/euslisp/EusLisp/pull/116")
+message(STATUS "COMMAND ${CMAKE_C_COMPILER} -I${euslisp_INCLUDE_DIRS} ${__CMAKE_COMPILE_DEFINITION} -c test-defun.c")
+
 execute_process (COMMAND ${CMAKE_C_COMPILER} -I${euslisp_INCLUDE_DIRS} ${__CMAKE_COMPILE_DEFINITION} -c test-defun.c
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   RESULT_VARIABLE TEST_DEFUN)


### PR DESCRIPTION
`catkin_make` fails to compile roseus, see https://travis-ci.org/jsk-ros-pkg/geneus/builds/452694267