### PR TITLE
Add method to convert jsk_recognition_msgs/BoundingBox to cube in euslisp

### DIFF
--- a/roseus/euslisp/roseus-utils.l
+++ b/roseus/euslisp/roseus-utils.l
@@ -616,6 +616,16 @@
              cb)) points)))
     ))
 ;;
+;; for boundingbox
+;;
+(ros::roseus-add-msgs "jsk_recognition_msgs")
+(defun boundingbox-msg->cube (msg)
+  "Convert jsk_recognition_msgs/BoundingBox to cube in euslisp"
+  (let* ((dims (ros::tf-point->pos (send msg :dimensions)))
+         (cube (make-cube (elt dims 0) (elt dims 1) (elt dims 2))))
+    (send cube :newcoords (ros::tf-pose->coords (send msg :pose)))
+    cube))
+;;
 ;; for pointcloud
 ;;
 (defun make-ros-msg-from-eus-pointcloud (pcloud &key (with-color :rgb)

--- a/roseus/package.xml
+++ b/roseus/package.xml
@@ -65,6 +65,7 @@
   <run_depend>message_runtime</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>actionlib_tutorials</run_depend>
+  <run_depend>jsk_recognition_msgs</run_depend>
 
   <test_depend>xvfb</test_depend>
 


### PR DESCRIPTION
I added a method to convert jsk_recognition_msgs/BoundingBox into cube in euslisp.
Pictures below are example of the conversion.

BoundingBox in Rviz
![boundingbox_rviz](https://user-images.githubusercontent.com/19769486/49071527-81efc200-f271-11e8-996b-049e1f4be1ff.png)

BoundingBox in euslisp
![boundingbox_eus](https://user-images.githubusercontent.com/19769486/49071546-89af6680-f271-11e8-87bc-17c47187db32.png)
