### PR TITLE
roseus: setlocale to none

### DIFF
--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -626,7 +626,13 @@ pointer ROSEUS(register context *ctx,int n,pointer *argv)
   s_mapServiced.clear();
   s_mapTimered.clear();
   s_mapHandle.clear();
-  
+
+  /*
+    set locale to none to let C RTL assume logging string can contain non-ascii characters.
+    Refer: https://logging.apache.org/log4cxx/latest_stable/faq.html
+  */
+  setlocale(LC_ALL, "");
+
   /*
     force to flag ros::init_options::NoSigintHandler.
     In fact, this code make no sence, because we steals


### PR DESCRIPTION
set locale to none to print non-ascii string in log message.

```lisp
$ roseus
3.irteusgl$ (ros::roseus "hhh")
4.irteusgl$ (ros::ros-info "ああ")
[ INFO] [1543630431.664127838] [/hhh_1543630392650267207:ros.roseus]: ??????
```

```lisp
$ roseus
1.irteusgl$ (ros::roseus "aaa")
t
2.irteusgl$ (ros::ros-info "あああ")
[ INFO] [1543630616.720022552] [/aaa_1543630597079538450:ros.roseus]: あああ
t
```