### PR TITLE
roseus_smach: pass userdata unless :arg-keys is set

### DIFF
--- a/roseus_smach/src/state-machine-utils.l
+++ b/roseus_smach/src/state-machine-utils.l
@@ -23,7 +23,7 @@ Returns:
     (while (ros::ok)
       (when spin
         (ros::spin-once)
-        (if (boundp '*ri*) (send *ri* :spin-once)))
+        (if (and (boundp '*ri*) *ri*) (send *ri* :spin-once)))
       (send insp :publish-status mydata)
       (when (send sm :goal-reached)
         (return))

--- a/roseus_smach/src/state-machine.l
+++ b/roseus_smach/src/state-machine.l
@@ -149,7 +149,7 @@
   ;; 0->this 1->sub 2->subsub ... -1->deepest
   (:execute
    (userdata &key (step nil))
-   (let ((args (mapcar #'(lambda(k)(cons k (cdr (assoc k userdata)))) arg-keys))
+   (let ((args (if arg-keys (mapcar #'(lambda (k) (cons k (cdr (assoc k userdata)))) arg-keys) userdata))
          result)
      (when (null active-state)
        (send self :reset-state))


### PR DESCRIPTION
The `userdata` on smach is lost and passed to the next state when no `:arg-keys` (for remapping userdata keys) is set.