### PR TITLE
Avoid segfault when unadvertised service is called

### DIFF
--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -1146,6 +1146,18 @@ pointer ROSEUS_SERVICE_CALL(register context *ctx,int n,pointer *argv)
   link = ros::ServiceManager::instance()->createServiceServerLink(client.getService(), client.isPersistent(), request.__getMD5Sum(), request.__getMD5Sum(), M_string());
   ros::SerializedMessage ser_req = ros::serialization::serializeMessage(request);
   ros::SerializedMessage ser_resp;
+  //check the existence of service
+  if (!service::exists(service, true)) {
+    ROS_ERROR("service  %s doesn't exist ",
+              ros::names::resolve(service).c_str());
+    if (service_cache.find(service) != service_cache.end()) {
+      service_cache.erase(service_cache.find(service));
+    }
+    link.reset();
+    vpop();                       // pop response._message
+    vpop();                       // pop request._message
+    return (response._message); //if the service doesn't exist, return
+  }
   bool bSuccess = link->call(ser_req, ser_resp);
   if ( bSuccess ) {
     try {

--- a/roseus/test/test-service-callback.l
+++ b/roseus/test/test-service-callback.l
@@ -32,6 +32,10 @@
   ;; this means callback is evaluated without segfault even when it does not return valid response.
   (assert t "callback is evaluated without segfault"))
 
+(deftest test-call-unadvertised-service ()
+  (ros::roseus "call_unadvertised_service")
+  (call-empty-service "dummy")
+  )
 
 
 (run-all-tests)


### PR DESCRIPTION
Check the existence of the service before link->call is executed. c.f. #575 

I think the following lines are required, but I'm not sure because I don't understand memory management well.
```
    link.reset();
    vpop();                       // pop response._message
    vpop();                       // pop request._message
```
https://github.com/ban-masa/jsk_roseus/blob/8afa74cd498c6712d678d3c154dbfe3e712b8e2b/roseus/roseus.cpp#L1149-L1151