### PR TITLE
Interface to call bullet collision distance computation from euslisp

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule ".travis"]
 	path = .travis
 	url = git://github.com/jsk-ros-pkg/jsk_travis
+[submodule "eusbullet/bullet3"]
+	path = eusbullet/bullet3
+	url = https://github.com/bulletphysics/bullet3.git

--- a/eusbullet/CMakeLists.txt
+++ b/eusbullet/CMakeLists.txt
@@ -21,3 +21,5 @@ include_directories(
 
 add_library(eusbullet SHARED src/eusbullet.cpp)
 target_link_libraries(eusbullet ${BULLET_LIBRARIES})
+
+add_rostest(test/test_collision_distance.test)

--- a/eusbullet/CMakeLists.txt
+++ b/eusbullet/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(eusbullet)
+
+find_package(catkin COMPONENTS cmake_modules rostest)
+
+catkin_package(
+    DEPENDS euslisp jskeus
+    LIBRARIES eusbullet BulletCollision BulletDynamics LinearMath ConvexDecomposition
+  )
+
+
+add_subdirectory(bullet3)
+
+set(BULLET_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/bullet3/src/)
+set(BULLET_LIBRARIES BulletCollision BulletDynamics LinearMath ConvexDecomposition)
+
+
+include_directories(
+  ${BULLET_INCLUDE_DIRS}
+  )
+
+add_library(eusbullet SHARED src/eusbullet.cpp)
+target_link_libraries(eusbullet ${BULLET_LIBRARIES})

--- a/eusbullet/README.md
+++ b/eusbullet/README.md
@@ -1,0 +1,28 @@
+# eusbullet
+
+EusLisp Interface for the Bullet Physics.
+
+## Build from source
+
+Just `catkin build` this package. You do not need to install bullet manually, and you do not need to remove it even if already exists.
+
+
+## Collisoin distance calculation
+
+#### How to use
+
+```
+roseus
+(load "package://eusbullet/euslisp/eusbullet.l")
+(bt-collision-distance obj1 obj2) ;; obj1, obj2 can be body or bodyset-link
+```
+
+#### Sample
+
+```
+roscd eusbullet/euslisp/sample
+roseus sample-collision-distance.l
+(sample-collision-distance-body)
+(sample-collision-distance-link)
+(sample-collision-distance-2d-analytical)
+```

--- a/eusbullet/euslisp/eusbullet.l
+++ b/eusbullet/euslisp/eusbullet.l
@@ -1,0 +1,175 @@
+(unless (find-package "BULLET") (make-package "BULLET" :nicknames '("BT")))
+(in-package "BT")
+
+(defvar *eusbullet-lib*
+  (labels
+      ((library_search
+        (str &key colon-pos lib-path)
+        (cond
+         ((eq (length str) 0)
+          (format t "~% libeusbullet.so not found~%")
+          (exit -1))
+         ((and (setq colon-pos (or (position #\: str) (length str)))
+               (setq lib-path (subseq str 0 colon-pos))
+               (setq lib-path
+                     (if (eq (aref lib-path (- (length lib-path) 1)) #\/)
+                         (subseq lib-path 0 (- (length lib-path) 1))
+                       lib-path))
+               (probe-file (setq lib-path
+                                 (format nil "~A/libeusbullet.so" lib-path))))
+          (load-foreign lib-path))
+         (t
+          (library_search (subseq str (min (length str) (+ colon-pos 1))))))))
+    (library_search (format nil "~A" (unix:getenv "LD_LIBRARY_PATH")))))
+
+
+;; long callMakeSphereModel(double radius)
+(defforeign make-sphere-model
+  *eusbullet-lib*
+  "callMakeSphereModel"
+  (:float)
+  :integer
+  )
+
+;; long callMakeBoxModel(double xsize, double ysize, double zsize)
+(defforeign make-box-model
+  *eusbullet-lib*
+  "callMakeBoxModel"
+  (:float :float :float)
+  :integer
+  )
+
+;; long callMakeCylinderModel(double radius, double height)
+(defforeign make-cylinder-model
+  *eusbullet-lib*
+  "callMakeCylinderModel"
+  (:float :float)
+  :integer
+  )
+
+;; long callMakeCapsuleModel(double radius, double height)
+(defforeign make-capsule-model
+  *eusbullet-lib*
+  "callMakeCapsuleModel"
+  (:float :float)
+  :integer
+  )
+
+;; long callMakeMeshModel(double *verticesPoints, long numVertices)
+(defforeign make-mesh-model
+  *eusbullet-lib*
+  "callMakeMeshModel"
+  (:string :integer)
+  :integer
+  )
+
+;; long callCalcCollisionDistance(long modelAddrA, long modelAddrB,
+;;                                double *posA, double *quatA, double *posB, double *quatB,
+;;                                double *dist, double *dir, double *pA, double *pB)
+(defforeign calc-collision-distance
+  *eusbullet-lib*
+  "callCalcCollisionDistance"
+  (:integer :integer
+   :string :string :string :string
+   :string :string :string :string)
+  :integer
+  )
+
+;; long callSetMargin(long modelAddr, double margin)
+(defforeign set-margin
+  *eusbullet-lib*
+  "callSetMargin"
+  (:integer :float)
+  :integer
+  )
+
+(defun make-model-from-body
+    (b &key (csg (send b :csg)) (margin nil) m)
+  (cond ((assoc :sphere csg)
+         (setq m
+               (make-sphere-model
+                (* 1e-3 (user::radius-of-sphere b)))
+               ))
+        ((assoc :cube csg)
+         (setq m
+               (make-box-model
+                (* 1e-3 (user::x-of-cube b))
+                (* 1e-3 (user::y-of-cube b))
+                (* 1e-3 (user::z-of-cube b)))
+               ))
+        ((assoc :cylinder csg)
+         (setq m
+               (make-cylinder-model
+                (* 1e-3 (user::radius-of-cylinder b))
+                (* 1e-3 (user::height-of-cylinder b)))
+               ))
+        (t
+         (setq m
+               (make-mesh-model
+                (scale 1e-3 ;; [m]
+                       (apply #'concatenate float-vector
+                              (mapcar #'(lambda (v) (send b :inverse-transform-vector v)) (send b :vertices))))
+                (length (send b :vertices))
+                ))
+         ))
+  (when margin
+    (bt::set-margin m margin))
+  m)
+
+(in-package "USER")
+
+(defmethod cascaded-coords
+  (:make-btmodel
+   (&key (fat 0) vs m)
+   (cond ((derivedp self body)
+          (setq m
+                (bt::make-model-from-body self :margin fat))
+          )
+         (t
+          (setq vs (flatten (send-all (send self :bodies) :vertices)))
+          (setq m
+                (bt::make-mesh-model
+                 (scale 1e-3 ;; [m]
+                        (apply #'concatenate float-vector
+                               (mapcar #'(lambda (v) (send self :inverse-transform-vector v)) vs)))
+                 (length vs)
+                 ))
+          (bt::set-margin m fat)
+          ))
+   (setf (get self :btmodel) m)
+   m)
+  )
+
+(defun bt-collision-distance
+    (model1 model2 &key (fat 0) (fat2 nil) (qsize))
+  "Calculate collision distance between model1 and model2 using Bullet.
+   Return value is (list [distance] [nearest point on model1] [nearest point on model2]).
+   If collision occurs, [distance] is 0 and nearest points are insignificant values.
+   qsize argument is not used, just for compatibility with pqp-collision-distance."
+  (let ((m1 (get model1 :btmodel))
+        (m2 (get model2 :btmodel))
+        (r1 (matrix2quaternion (send model1 :worldrot)))
+        (t1 (scale 1e-3 (send model1 :worldpos))) ;; [m]
+        (r2 (matrix2quaternion (send model2 :worldrot)))
+        (t2 (scale 1e-3 (send model2 :worldpos))) ;; [m]
+        (dist (float-vector 0))
+        (dir (float-vector 0 0 0))
+        (p1 (float-vector 0 0 0))
+        (p2 (float-vector 0 0 0))
+        r)
+    (if (null fat2) (setq fat2 fat))
+    (if (null m1) (setq m1 (send model1 :make-btmodel :fat fat)))
+    (if (null m2) (setq m2 (send model2 :make-btmodel :fat fat2)))
+    (bt::calc-collision-distance
+     m1 m2 t1 r1 t2 r2
+     dist dir p1 p2)
+    (list (* 1e3 (elt dist 0)) (scale 1e3 p1) (scale 1e3 p2))
+    ))
+
+(defun bt-collision-check
+    (model1 model2 &key (fat 0) (fat2 nil))
+  "Check collision between model1 and model2 using Bullet.
+   If return value is 0, no collision.
+   Otherwise (return value is 1), collision."
+  (if (> (elt (bt-collision-distance model1 model2 :fat fat :fat2 fat2) 0) 0) 0 1)
+  )

--- a/eusbullet/euslisp/sample/sample-collision-distance.l
+++ b/eusbullet/euslisp/sample/sample-collision-distance.l
@@ -1,0 +1,174 @@
+(load "../eusbullet.l")
+(load "irteus/demo/sample-arm-model.l")
+
+
+(defun sample-collision-distance-body
+    (&key
+     (obj1 (make-cube 200 300 500))
+     (obj2 (make-cube 400 600 1000))
+     (collision-distance-func #'bt-collision-distance) ;; you can try #'pqp-collision-distance
+     (obj1-coords-func
+      #'(lambda (cnt) (make-coords :pos (float-vector 1000 0 0))))
+     (obj2-coords-func
+      #'(lambda (cnt)
+          (make-coords
+           :pos (float-vector (* 1500 (sin (/ cnt 100.0))) (* 500 (sin (+ (/ cnt 200.0) (deg2rad 45)))) 0)
+           :rpy (list (* pi (sin (/ cnt 200.0))) (+ (* pi (sin (/ cnt 400.0))) pi/2) 0)
+           )))
+     )
+  (let* ((cnt 0)
+         (ret)
+         )
+    (when obj1-coords-func
+      (send obj1 :newcoords (funcall obj1-coords-func (float cnt))))
+    (when obj2-coords-func
+      (send obj2 :newcoords (funcall obj2-coords-func (float cnt))))
+    (send obj1 :set-color (float-vector 1 0 0) 0.5)
+    (send obj2 :set-color (float-vector 0 1 0) 0.4)
+    (objects (list obj1 obj2))
+
+    (do-until-key
+     ;; move object
+     (incf cnt)
+     (when obj1-coords-func
+       (send obj1 :newcoords (funcall obj1-coords-func (float cnt))))
+     (when obj2-coords-func
+       (send obj2 :newcoords (funcall obj2-coords-func (float cnt))))
+     (send *irtviewer* :draw-objects)
+     ;; get distance beween target-link and obj
+     (setq ret (funcall collision-distance-func obj1 obj2))
+     ;; draw
+     (send (elt ret 1) :draw-on :flush nil :width 16 :size 50 :color (float-vector 1 0.4 0.4))
+     (send (elt ret 2) :draw-on :flush nil :width 16 :size 50 :color (float-vector 0.4 1 0.4))
+     (send (make-line (elt ret 1) (elt ret 2)) :draw-on :flush nil
+           :width 8 :color (if (> (elt ret 0) 0) (float-vector 0 1 1) (float-vector 1 1 0)))
+     (send *irtviewer* :viewer :flush)
+     (unix::usleep (* 20 1000))
+     (x::window-main-one)
+     )
+    ))
+(warn "(sample-collision-distance-body)~%")
+
+(defun sample-collision-distance-sphere
+    ()
+  (sample-collision-distance-body
+   :obj2 (make-sphere 600))
+  )
+
+(defun sample-collision-distance-cube
+    ()
+  (sample-collision-distance-body)
+  )
+
+(defun sample-collision-distance-cylinder
+    ()
+  (sample-collision-distance-body
+   :obj2 (make-cylinder 400 1200)
+   )
+  )
+
+(defun sample-collision-distance-conv
+    ()
+  (sample-collision-distance-body
+   :obj2 (make-cone (float-vector 0 0 1500) (list (float-vector -800 -500 0) (float-vector 800 -500 0) (float-vector 0 500 0)))
+   )
+  )
+
+
+(defun sample-collision-distance-link
+    (&key
+     (obj (make-cube 200 500 500))
+     (collision-distance-func #'bt-collision-distance)
+     (obj-coords-func
+      #'(lambda (cnt) (make-coords :pos (float-vector 500 0 250))))
+     )
+  (let* ((cnt 0)
+         (ret)
+         (robot (instance sarmclass :init))
+         (target-link (elt (send robot :links) 4))
+         (base-link (elt (send robot :links) 0))
+         )
+    (when obj-coords-func
+      (send obj :newcoords (funcall obj-coords-func (float cnt))))
+    (send obj :set-color (float-vector 1 0 0) 0.5)
+    (objects (list robot obj))
+
+    (do-until-key
+     ;; move object and robot
+     (incf cnt)
+     (dolist (j (send robot :joint-list))
+       (send j :joint-angle
+             (+ (* 0.49 (- (send j :max-angle) (send j :min-angle)) (sin (/ cnt 100.0)))
+                (* 0.5 (+ (send j :max-angle) (send j :min-angle)))))
+       )
+     (when obj-coords-func
+       (send obj :newcoords (funcall obj-coords-func (float cnt))))
+     (send obj :newcoords (funcall obj-coords-func (float cnt)))
+     (send *irtviewer* :draw-objects)
+     ;; get distance beween target-link and obj
+     (setq ret (funcall collision-distance-func target-link obj))
+     (send (elt ret 1) :draw-on :flush nil :width 16 :size 50 :color (float-vector 1 0.4 0.4))
+     (send (elt ret 2) :draw-on :flush nil :width 16 :size 50 :color (float-vector 0.4 1 0.4))
+     (send (make-line (elt ret 1) (elt ret 2)) :draw-on :flush nil
+           :width 8 :color (if (> (elt ret 0) 0) (float-vector 0 1 1) (float-vector 1 1 0)))
+     ;; get distance beween target-link and base-link
+     (setq ret (funcall collision-distance-func target-link base-link))
+     ;; draw
+     (send (elt ret 1) :draw-on :flush nil :width 16 :size 50 :color (float-vector 1 0.4 0.4))
+     (send (elt ret 2) :draw-on :flush nil :width 16 :size 50 :color (float-vector 0.4 1 0.4))
+     (send (make-line (elt ret 1) (elt ret 2)) :draw-on :flush nil
+           :width 8 :color (if (> (elt ret 0) 0) (float-vector 0 1 1) (float-vector 1 1 0)))
+     (send *irtviewer* :viewer :flush)
+     (unix::usleep (* 20 1000))
+     (x::window-main-one)
+     )
+    ))
+(warn "(sample-collision-distance-link)~%")
+
+
+(defun sample-collision-distance-2d-analytical
+    (&key
+     (max-cnt)
+     (visualize? t)
+     )
+  (let* ((radius1 100)
+         (radius2 200)
+         (obj1 (make-sphere radius1))
+         (obj2 (make-sphere radius2))
+         (cnt 0)
+         (bt-dist)
+         (analy-dist)
+         (ret)
+         )
+    (send obj1 :set-color (float-vector 1 0 0) 0.5)
+    (send obj2 :set-color (float-vector 0 1 0) 0.4)
+    (when visualize?
+      (objects (list obj1 obj2)))
+
+    (do-until-key
+      ;; move object
+      (incf cnt)
+      (send obj1 :newcoords (make-coords :pos (float-vector (* 500.0 (sin (/ cnt 100.0))) 50 0)))
+      (when visualize?
+        (send *irtviewer* :draw-objects))
+      ;; get bullet distance
+      (setq ret (bt-collision-distance obj1 obj2))
+      (setq bt-dist (elt ret 0))
+      ;; get analytical distance and compare
+      (setq analy-dist (- (norm (send obj1 :worldpos)) (+ radius1 radius2)))
+      (assert (eps= bt-dist analy-dist 1e-3))
+      ;; draw
+      (when visualize?
+        (send (elt ret 1) :draw-on :flush nil :width 16 :size 50 :color (float-vector 1 0.4 0.4))
+        (send (elt ret 2) :draw-on :flush nil :width 16 :size 50 :color (float-vector 0.4 1 0.4))
+        (send (make-line (elt ret 1) (elt ret 2)) :draw-on :flush nil
+              :width 8 :color (if (> (elt ret 0) 0) (float-vector 0 1 1) (float-vector 1 1 0)))
+        (send *irtviewer* :viewer :flush)
+        (unix::usleep (* 20 1000))
+        (x::window-main-one)
+        )
+      (when (and max-cnt (> cnt max-cnt))
+        (return-from nil nil))
+      )
+    ))
+(warn "(sample-collision-distance-2d-analytical)~%")

--- a/eusbullet/package.xml
+++ b/eusbullet/package.xml
@@ -1,0 +1,22 @@
+<package>
+  <name>eusbullet</name>
+  <version>0.1.0</version>
+  <description>EusLisp Interface for the Bullet Physics.</description>
+  <maintainer email="murooka@jsk.t.u-tokyo.ac.jp">Masaki Murooka</maintainer>
+
+  <license>BSD</license>
+
+  <url type="website">http://pr.willowgarage.com/wiki/eusbullet</url>
+  <!-- <url type="bugtracker"></url> -->
+
+  <author email="murooka@jsk.t.u-tokyo.ac.jp">Masaki Murooka</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>euslisp</build_depend>
+  <build_depend>jskeus</build_depend>
+
+  <run_depend>euslisp</run_depend>
+  <run_depend>jskeus</run_depend>
+
+</package>

--- a/eusbullet/src/eusbullet.cpp
+++ b/eusbullet/src/eusbullet.cpp
@@ -1,0 +1,192 @@
+#include "btBulletCollisionCommon.h"
+#include "BulletCollision/NarrowPhaseCollision/btGjkCollisionDescription.h"
+#include "BulletCollision/NarrowPhaseCollision/btVoronoiSimplexSolver.h"
+#include "BulletCollision/NarrowPhaseCollision/btComputeGjkEpaPenetration.h"
+#include "LinearMath/btGeometryUtil.h"
+
+
+struct btDistanceInfo
+{ // this class is copied from https://github.com/bulletphysics/bullet3/blob/master/test/collision/btDistanceInfo.h
+  btVector3 m_pointOnA;
+  btVector3 m_pointOnB;
+  btVector3 m_normalBtoA;
+  btScalar m_distance;
+};
+
+
+struct ConvexWrap
+{ // this class is copied from https://github.com/bulletphysics/bullet3/blob/master/test/collision/main.cpp
+  btConvexShape* m_convex;
+  btTransform m_worldTrans;
+  inline btScalar getMargin() const
+  {
+    return m_convex->getMargin();
+  }
+  inline btVector3 getObjectCenterInWorld() const
+  {
+    return m_worldTrans.getOrigin();
+  }
+  inline const btTransform& getWorldTransform() const
+  {
+    return m_worldTrans;
+  }
+  inline btVector3 getLocalSupportWithMargin(const btVector3& dir) const
+  {
+    return m_convex->localGetSupportingVertex(dir);
+  }
+  inline btVector3 getLocalSupportWithoutMargin(const btVector3& dir) const
+  {
+    return m_convex->localGetSupportingVertexWithoutMargin(dir);
+  }
+};
+
+long makeSphereModel(double radius)
+{
+  return (long)(new btSphereShape(radius));
+};
+
+long makeBoxModel(double xsize, double ysize, double zsize)
+{
+  return (long)(new btBoxShape(0.5*btVector3(xsize, ysize, zsize)));
+};
+
+long makeCylinderModel(double radius, double height)
+{
+  return (long)(new btCylinderShapeZ(btVector3(radius, radius, 0.5*height)));
+};
+
+long makeCapsuleModel(double radius, double height)
+{
+  return (long)(new btCapsuleShapeZ(radius, 0.5*height));
+};
+
+long makeMeshModel(double *verticesPoints, long numVertices)
+{
+  btConvexHullShape* pshape = new btConvexHullShape();
+#define SHRINK_FOR_MARGIN false
+  if (SHRINK_FOR_MARGIN) {
+    // Shrink vertices for default margin CONVEX_DISTANCE_MARGIN,
+    // which should be nonzero positive for fast computation of penetration distance.
+    // ref: https://pybullet.org/Bullet/phpBB3/viewtopic.php?t=2358#p9411
+    // But sometimes, this doesn't work well (vertices become empty), so currently disabled.
+    btAlignedObjectArray<btVector3> vertices;
+    for (int i = 0; i < 3 * numVertices; i += 3) {
+      vertices.push_back(btVector3(verticesPoints[i], verticesPoints[i+1], verticesPoints[i+2]));
+    }
+    btAlignedObjectArray<btVector3> planes;
+    btGeometryUtil::getPlaneEquationsFromVertices(vertices, planes);
+    int sz = planes.size();
+    for (int i = 0 ; i < sz ; i++) {
+      planes[i][3] += CONVEX_DISTANCE_MARGIN;
+    }
+    vertices.clear();
+    btGeometryUtil::getVerticesFromPlaneEquations(planes, vertices);
+    sz = vertices.size();
+    for (int i = 0 ; i < sz ; i++) {
+      pshape->addPoint(vertices[i]);
+    }
+  } else {
+    for (int i = 0; i < 3 * numVertices; i += 3) {
+      pshape->addPoint(btVector3(verticesPoints[i], verticesPoints[i+1], verticesPoints[i+2]));
+    }
+  }
+  return (long)pshape;
+};
+
+long calcCollisionDistance(long modelAddrA, long modelAddrB,
+                           double *posA, double *quatA, double *posB, double *quatB,
+                           double *dist, double *dir, double *pA, double *pB)
+{
+  ConvexWrap a, b;
+  a.m_convex = ((btConvexShape *)modelAddrA);
+  a.m_worldTrans.setOrigin(btVector3(posA[0], posA[1], posA[2]));
+  a.m_worldTrans.setRotation(btQuaternion(quatA[1], quatA[2], quatA[3], quatA[0])); // w is first element in euslisp
+  b.m_convex = ((btConvexShape *)modelAddrB);
+  b.m_worldTrans.setOrigin(btVector3(posB[0], posB[1], posB[2]));
+  b.m_worldTrans.setRotation(btQuaternion(quatB[1], quatB[2], quatB[3], quatB[0])); // w is first element in euslisp
+  // The origin of euslisp cylinder model is located on bottom, so local translation of half height is necessary
+  if(btCylinderShapeZ* cly = dynamic_cast<btCylinderShapeZ*>(a.m_convex)) {
+    btVector3 heightOffset(btVector3(0, 0, cly->getHalfExtentsWithMargin().getZ()));
+    a.m_worldTrans.setOrigin(a.m_worldTrans.getOrigin() + a.m_worldTrans.getBasis() * heightOffset);
+  }
+  if(btCylinderShapeZ* cly = dynamic_cast<btCylinderShapeZ*>(b.m_convex)) {
+    btVector3 heightOffset(btVector3(0, 0, cly->getHalfExtentsWithMargin().getZ()));
+    b.m_worldTrans.setOrigin(b.m_worldTrans.getOrigin() + b.m_worldTrans.getBasis() * heightOffset);
+  }
+
+  btGjkCollisionDescription colDesc;
+  btVoronoiSimplexSolver simplexSolver;
+  btDistanceInfo distInfo;
+  int res = -1;
+  simplexSolver.reset();
+  res = btComputeGjkEpaPenetration(a, b, colDesc, simplexSolver, &distInfo);
+
+  // The result of btComputeGjkEpaPenetration is offseted by CONVEX_DISTANCE_MARGIN.
+  // Although the offset is considered internally in primitive shapes, not considered in convex hull shape.
+  // So, the result is modified manually.
+  if(dynamic_cast<btConvexHullShape*>((btConvexShape *)modelAddrA)) {
+    distInfo.m_distance += CONVEX_DISTANCE_MARGIN;
+    distInfo.m_pointOnA += CONVEX_DISTANCE_MARGIN * distInfo.m_normalBtoA;
+  }
+  if(dynamic_cast<btConvexHullShape*>((btConvexShape *)modelAddrB)) {
+    distInfo.m_distance += CONVEX_DISTANCE_MARGIN;
+    distInfo.m_pointOnB += - CONVEX_DISTANCE_MARGIN * distInfo.m_normalBtoA;
+  }
+
+  *dist = distInfo.m_distance;
+  for (int i = 0; i < 3; i++) {
+    dir[i] = distInfo.m_normalBtoA[i];
+    pA[i] = distInfo.m_pointOnA[i];
+    pB[i] = distInfo.m_pointOnB[i];
+  }
+
+  return res;
+};
+
+long setMargin(long modelAddr, double margin)
+{
+  // shape are shrinked for CONVEX_DISTANCE_MARGIN, so CONVEX_DISTANCE_MARGIN is added to margin
+  ((btConvexShape *)modelAddr)->setMargin(CONVEX_DISTANCE_MARGIN+margin);
+  return 0;
+};
+
+extern "C" {
+  long callMakeSphereModel(double radius)
+  {
+    return makeSphereModel(radius);
+  }
+
+  long callMakeBoxModel(double xsize, double ysize, double zsize)
+  {
+    return makeBoxModel(xsize, ysize, zsize);
+  }
+
+  long callMakeCylinderModel(double radius, double height)
+  {
+    return makeCylinderModel(radius, height);
+  }
+
+  long callMakeCapsuleModel(double radius, double height)
+  {
+    return makeCapsuleModel(radius, height);
+  }
+
+  long callMakeMeshModel(double *verticesPoints, long numVertices)
+  {
+    return makeMeshModel(verticesPoints, numVertices);
+  }
+
+  long callCalcCollisionDistance(long modelAddrA, long modelAddrB,
+                                 double *posA, double *quatA, double *posB, double *quatB,
+                                 double *dist, double *dir, double *pA, double *pB)
+  {
+    return calcCollisionDistance(modelAddrA, modelAddrB,
+                                 posA, quatA, posB, quatB,
+                                 dist, dir, pA, pB);
+  }
+
+  long callSetMargin(long modelAddr, double margin)
+  {
+    return setMargin(modelAddr, margin);
+  }
+}

--- a/eusbullet/test/test-collision-distance.l
+++ b/eusbullet/test/test-collision-distance.l
@@ -1,0 +1,15 @@
+#!/usr/bin/env roseus
+
+(require :unittest "lib/llib/unittest.l")
+(load "../euslisp/sample/sample-collision-distance.l")
+
+
+(init-unit-test)
+
+(deftest test-sample-collision-distance-2d-analytical
+  (sample-collision-distance-2d-analytical :max-cnt 500 :visualize? nil)
+  )
+
+
+(run-all-tests)
+(exit)

--- a/eusbullet/test/test_collision_distance.test
+++ b/eusbullet/test/test_collision_distance.test
@@ -1,0 +1,4 @@
+<launch>
+  <test test-name="test_collision_distance" pkg="eusbullet" type="test-collision-distance.l" time-limit="2000.0">
+  </test>
+</launch>


### PR DESCRIPTION
Call [`btComputeGjkEpaPenetration`](https://pybullet.org/Bullet/BulletFull/btComputeGjkEpaPenetration_8h.html) function from euslisp by defforeign.
This methods can compute not only the distance without collision but also the **penetration depth** while two objects colliding.
To calculate penetration depth, GJK algorithm is not enough, and EPA algorithm is necessary. (ref. first sentende in http://www.dyn4j.org/2010/05/epa-expanding-polytope-algorithm/ )

In my understanding, PQP can calculate distancee without collision, but once the objects collide, the returned distance is no longer meaningless.
In order to avoid collision between a robot link and obstacles correctly in inverse kinematics or motion planning, the penetration depth while colliding is necessary.
I knew the bullet implementation of GJK and EPA algorithm from  [trajopt](https://github.com/joschu/trajopt/tree/master/ext/bullet) paper saying that they use it for collision avoidance: http://rll.berkeley.edu/trajopt/ijrr/2013-IJRR-TRAJOPT.pdf.

I do not think this is the best repository or way to add this, so I don't hurry to merge this.


Newly added function is compatible with pqp. Just call `(bt-collision-distance obj1 obj2)` instead of `(pqp-collision-distance obj1 obj2)`. See [README](https://github.com/mmurooka/jsk_roseus/blob/09743e1c65a8554a1da0e6fd5165ffae7af37093/eusbullet/README.md).


The result is validated with sphere-sphere example by comparing analytical results, which is same with [test in bullet](https://github.com/bulletphysics/bullet3/blob/master/test/collision/main.cpp).
![2d-analytical](https://user-images.githubusercontent.com/6636600/53302044-7d04d380-389d-11e9-8350-e9d392714962.gif)

If we use `pqp-collision-distance`, penetration depth is invalid.
![2d-analytical-pqp](https://user-images.githubusercontent.com/6636600/53302051-82fab480-389d-11e9-8070-63d60c385a25.gif)

Cube-cube example with bullet.
![distance-cube](https://user-images.githubusercontent.com/6636600/53302053-8726d200-389d-11e9-8aae-01e46f7be52c.gif)

Bodysetlink-cube example with bullet. Collision between the 4th link of manipulator (orange one) and the read obstacle is calculated.
![robot-link-obstacle](https://user-images.githubusercontent.com/6636600/53302055-8e4de000-389d-11e9-8f9c-1b06a57e4344.gif)

Example of use in inverse kinematics. If we use bullet, we can **start IK from the collision posture**, although PQP does not gurantee correct collision avoidance in such case.
bullet:
![ik-bullet](https://user-images.githubusercontent.com/6636600/53302057-93129400-389d-11e9-869b-518991474bde.gif)

pqp:
![ik-pqp](https://user-images.githubusercontent.com/6636600/53302062-99087500-389d-11e9-8130-92be7d08278d.gif)

