### PR TITLE
Ignore _connection-header in 'print-ros-msg'

### DIFF
--- a/roseus/CMakeLists.txt
+++ b/roseus/CMakeLists.txt
@@ -202,4 +202,5 @@ if(CATKIN_ENABLE_TESTING)
   #add_rostest(test/test-genmsg-oneworkspace.catkin.launch) # use launch not to run on travis/catkin
   add_rostest(test/test-geneus.test)
   add_rostest(test/test-compile-message.test)
+  add_rostest(test/test-print-ros-msg.test)
 endif()

--- a/roseus/euslisp/roseus-utils.l
+++ b/roseus/euslisp/roseus-utils.l
@@ -8,7 +8,10 @@
 
 (defun print-ros-msg (msg &optional (rp (find-package "ROS"))
                           (ro ros::object) (nest 0) (padding "  "))
-  (dolist (s (send msg :slots))
+  (dolist (s (let ((slt (send msg :slots)))
+               (map nil #'(lambda (obj) (setq slt (remove obj slt :key #'car :count 1)))
+                    (send ro :slots))
+               slt))
     (let ((sm (car s)))
       (when (and (symbolp sm) (eq (symbol-package sm) rp))
         (cond

--- a/roseus/euslisp/roseus-utils.l
+++ b/roseus/euslisp/roseus-utils.l
@@ -9,6 +9,8 @@
 (defun print-ros-msg (msg &optional (rp (find-package "ROS"))
                           (ro ros::object) (nest 0) (padding "  "))
   (dolist (s (let ((slt (send msg :slots)))
+               ;; `s' is a list of slots unique to the msg object
+               ;; i.e. slots present in `ro' and inherited by `msg' are filtered
                (map nil #'(lambda (obj) (setq slt (remove obj slt :key #'car :count 1)))
                     (send ro :slots))
                slt))

--- a/roseus/test/test-print-ros-msg.l
+++ b/roseus/test/test-print-ros-msg.l
@@ -1,0 +1,54 @@
+#!/usr/bin/env roseus
+;;
+
+(require :unittest "lib/llib/unittest.l")
+
+(init-unit-test)
+
+
+(deftest test-print-ros-msg ()  
+  (let ((result-string
+         (with-output-to-string (s)
+           (let ((msg (ros::coords->tf-pose (make-coords :pos #f(1.0 2.0 3.0))))
+                 (*standard-output* s))
+             (print-ros-msg msg))))
+        (expected-string
+":position -- geometry_msgs::point
+  :x
+  0.001
+  :y
+  0.002
+  :z
+  0.003
+:orientation -- geometry_msgs::quaternion
+  :x
+  0.0
+  :y
+  0.0
+  :z
+  0.0
+  :w
+  1.0
+"":position -- geometry_msgs::point
+  :x
+  0.001
+  :y
+  0.002
+  :z
+  0.003
+:orientation -- geometry_msgs::quaternion
+  :x
+  0.0
+  :y
+  0.0
+  :z
+  0.0
+  :w
+  1.0
+"))
+    (assert (string= result-string expected-string))))
+
+
+(run-all-tests)
+
+(exit)

--- a/roseus/test/test-print-ros-msg.test
+++ b/roseus/test/test-print-ros-msg.test
@@ -1,0 +1,3 @@
+<launch>
+  <test test-name="test_print_ros_msg" pkg="roseus" type="roseus" args="$(find roseus)/test/test-print-ros-msg.l" />
+</launch>


### PR DESCRIPTION
Ignoring `_connection-header`, `plist` and any other slots added to the `ros::object` class when printing ros messages with `print-ros-msg`.

Strictly speaking this makes the `(eq (symbol-package sm) rp)` part pointless, which leads to having `rp` as an unused argument. This is not changed to maintain backward compability.

https://github.com/jsk-ros-pkg/jsk_roseus/pull/605