### PR TITLE
Remove unmatched parenthesis

### DIFF
--- a/roseus/euslisp/roseus.l
+++ b/roseus/euslisp/roseus.l
@@ -62,13 +62,12 @@
 (shadow 'object *package*)
 (defclass ros::object
   :super propertied-object
-  :slots (_connection-header)))
+  :slots (_connection-header))
 (defmethod ros::object
   (:init () self)
   (:md5sum- () (get (class self) :md5sum-))
   (:datatype- ()  (get (class self) :datatype-))
   (:connection-header () _connection-header))
-  )
 
 (shadow 'time *package*)
 (defclass ros::time


### PR DESCRIPTION
Actually noticed some unmatching parenthesis on `roseus.l`, so am reporting it.