### PR TITLE
Allow to load pathnames

### DIFF
--- a/roseus/euslisp/roseus.l
+++ b/roseus/euslisp/roseus.l
@@ -240,7 +240,7 @@
 
 (defun load (fname &rest args)
   (let ((fullname fname))
-    (when (substringp "package://" fname)
+    (when (and (stringp fname) (substringp "package://" fname))
       (setq fullname (ros::resolve-ros-path fname))
       (when ros::*compile-message*
         (let* ((urlname (url-pathname fname))

--- a/roseus/test/test-roseus.l
+++ b/roseus/test/test-roseus.l
@@ -111,6 +111,12 @@
   (assert (not (ros::resolve-ros-path "package://not_existing_package")))
   )
 
+(deftest load-pathname ()
+  (let ((fname (concatenate string #+:linux "/tmp/" "tmp-load-pathname-test.l")))
+    (with-open-file (file fname :direction :output)
+      (format file "(print \"Loaded.\")"))
+    (assert (eq (load (pathname fname)) t))))
+
 (deftest test-image-conversion ()
   (when (and
          (assoc :create-viewer (send camera-model :methods))


### PR DESCRIPTION
Allows to load pathnames, which are supported in `eus` but leads to the following error in `roseus`.

```lisp
$ (load #P"/tmp/test.l")
;; sequence expected in (substringp "package://" fname)
```