### PR TITLE
[roseus_tutotrials] Add euslisp example using hsi_color_filter

### DIFF
--- a/roseus_tutorials/launch/hsi_color_filter.launch
+++ b/roseus_tutorials/launch/hsi_color_filter.launch
@@ -19,8 +19,8 @@
   <arg name="h_min" default="-128" />
   <arg name="s_max" default="255" />
   <arg name="s_min" default="0" />
-  <arg name="v_max" default="255" />
-  <arg name="v_min" default="0" />
+  <arg name="i_max" default="255" />
+  <arg name="i_min" default="0" />
 
   <arg name="create_manager" default="true" />
   <arg name="manager" default="hsi_filter_manager" />
@@ -35,8 +35,8 @@
     <arg name="h_min" default="$(arg h_min)" />
     <arg name="s_max" default="$(arg s_max)" />
     <arg name="s_min" default="$(arg s_min)" />
-    <arg name="v_max" default="$(arg v_max)" />
-    <arg name="v_min" default="$(arg v_min)" />
+    <arg name="i_max" default="$(arg i_max)" />
+    <arg name="i_min" default="$(arg i_min)" />
 
     <arg name="create_manager" default="$(arg create_manager)" />
     <arg name="manager" default="$(arg manager)" />

--- a/roseus_tutorials/package.xml
+++ b/roseus_tutorials/package.xml
@@ -38,6 +38,7 @@
   <run_depend>jsk_recognition_msgs</run_depend>
   <!-- <run_depend>tabletop_object_detector</run_depend> -->
 
+  <test_depend>jsk_pcl_ros</test_depend>
   <test_depend>rostest</test_depend>
   <export>
   </export>

--- a/roseus_tutorials/src/display-bounding-box-array.l
+++ b/roseus_tutorials/src/display-bounding-box-array.l
@@ -1,0 +1,34 @@
+#!/usr/bin/env roseus
+
+(ros::load-ros-manifest "jsk_recognition_msgs")
+
+
+(defun bounding-box-array-cb (msg)
+  (let ((bounding-box-list (send msg :boxes)))
+    (when bounding-box-list
+      (send *irtviewer* :draw-objects :flush nil)
+      (mapcar
+       #'(lambda (b)
+           (let* ((dims (ros::tf-point->pos (send b :dimensions)))
+                  (bx (make-cube (elt dims 0) (elt dims 1) (elt dims 2)))
+                  (cam->obj-coords (ros::tf-pose->coords (send b :pose))))
+             (send bx :newcoords cam->obj-coords)
+             (send bx :worldcoords)
+             (send bx :draw-on :flush nil :color #f(1 0 0))
+             bx))
+       bounding-box-list)
+      (send *irtviewer* :viewer :viewsurface :flush)
+      )))
+
+
+(ros::roseus "bounding_box_array_subscriber")
+(unless (boundp '*irtviewer*) (make-irtviewer))
+
+(ros::subscribe "~input_boxes" jsk_recognition_msgs::BoundingBoxArray
+                #'bounding-box-array-cb 1)
+
+(do-until-key
+ (x::window-main-one)
+ (ros::spin-once)
+ (ros::sleep)
+ )


### PR DESCRIPTION
Moved from #613 

I added `display-bounding-box-array.l` as an example of visualizing the result of `hsi_color_filter.launch` in roseus_tutorials.

![display_bounding_box_array](https://user-images.githubusercontent.com/22876283/55717055-74bebd00-5a33-11e9-86ec-7d91d229cc6a.png)
