### PR TITLE
Check for sigint interruptions on ros functions

### DIFF
--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -1076,16 +1076,17 @@ pointer ROSEUS_GETTOPICPUBLISHER(register context *ctx,int n,pointer *argv)
 pointer ROSEUS_WAIT_FOR_SERVICE(register context *ctx,int n,pointer *argv)
 {
   isInstalledCheck;
+  numunion nu;
   string service;
 
   ckarg2(1,2);
   if (isstring(argv[0])) service = ros::names::resolve((char *)get_string(argv[0]));
   else error(E_NOSTRING);
 
-  int32_t timeout = -1;
+  float timeout = -1;
 
   if( n > 1 )
-    timeout = (int32_t)ckintval(argv[1]);
+    timeout = ckfltval(argv[1]);
 
   bool bSuccess = service::waitForService(service, ros::Duration(timeout));
 

--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -564,6 +564,7 @@ void roseusSignalHandler(int sig)
     // memoize for euslisp handler...
     context *ctx=euscontexts[thr_self()];
     ctx->intsig = sig;
+    ros::Time::shutdown();
 }
 
 /************************************************************


### PR DESCRIPTION
Talking to @YutoUchimi this morning we realized that a call for `ros::wait-for-service` cannot be interrupted by `C-c`. This also applies to `ros::duration-sleep` and `ros::sleep`.

In this PR we allow to `C-c` such functions by:
1. Sending a shutdown signal to ros timers on roseus sigint handler (for `ros::duration-sleep` and `ros::sleep`)
1. Re-writing the `ros::wait-for-service` based on the original [service.cpp](http://docs.ros.org/electric/api/roscpp/html/service_8cpp_source.html) definition, in order to check the `ctx->intsig` flag (similar to `ros::spin`)