### PR TITLE
Add command line option to start roseus with gdb

### DIFF
--- a/roseus/bin/roseus.in
+++ b/roseus/bin/roseus.in
@@ -10,18 +10,20 @@ ROSEUS_DIR=`rospack find roseus`
 ARG_STR=("(pushnew \"${ROSEUS_DIR}/euslisp/\" *load-path* :test #'equal)" \
         ${ROSEUS_DIR}/euslisp/roseus.l ${ROSEUS_DIR}/euslisp/eustf.l ${ROSEUS_DIR}/euslisp/actionlib.l ${ROSEUS_DIR}/euslisp/roseus-utils.l)
 # echo "rosrun euslisp irteusgl ${ARG_STR[@]} $@"
-exec ${EUSLISP_EXE} "${ARG_STR[@]}" "$@"
 
-# if you want to run in gdb, please use lines below
-# CMD_NAME=/tmp/roseus_$$
-# cat <<EOF > $CMD_NAME
-# break error
-# run
-# where
+LAUNCH_PREFIX="exec"
+case $1 in
+    --gdb)
+        shift # past argument
+        GDB_OPTIONS=/tmp/roseus_$$
+        cat <<EOF > $GDB_OPTIONS
+break error
+run
+where
 
-# EOF
-# gdb -x $CMD_NAME --args `rospack find euslisp`/jskeus/eus/Linux64/bin/irteusgl "${ARG_STR[@]}" "$@"
-# rm -rf $CMD_NAME
-# // end of using gdb
+EOF
+        LAUNCH_PREFIX="gdb -x $GDB_OPTIONS --args"
+esac
 
+${LAUNCH_PREFIX} ${EUSLISP_EXE} "${ARG_STR[@]}" "$@"
 exit $?

--- a/roseus/bin/roseus.in
+++ b/roseus/bin/roseus.in
@@ -15,7 +15,7 @@ LAUNCH_PREFIX="exec"
 case $1 in
     --gdb)
         shift # past argument
-        GDB_OPTIONS=/tmp/roseus_$$
+        GDB_OPTIONS=/tmp/roseus_gdbinit
         cat <<EOF > $GDB_OPTIONS
 break error
 commands

--- a/roseus/bin/roseus.in
+++ b/roseus/bin/roseus.in
@@ -18,9 +18,10 @@ case $1 in
         GDB_OPTIONS=/tmp/roseus_$$
         cat <<EOF > $GDB_OPTIONS
 break error
-run
+commands
 where
-
+end
+run
 EOF
         LAUNCH_PREFIX="gdb -x $GDB_OPTIONS --args"
 esac


### PR DESCRIPTION
I've been needing some more debugging aid in euslisp, and decided to run roseus with gdb on, as pointed out in the roseus executable itself.

~~Not much difference, but in this PR am updating the gdb related comment to use the same irteusgl executable as the standard command.~~

EDIT:
Incorporating @k-okada suggestion to add an command line argument `--gdb` to start roseus in the gdb mode.