### PR TITLE
Avoid gc when registering subscribers

### DIFF
--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -369,8 +369,11 @@ public:
       ROS_ERROR("subscription callback function install error");
     }
     // avoid gc
+    vpush(scb); vpush(args);
     pointer p=gensym(ctx);
     setval(ctx,intern(ctx,(char*)(p->c.sym.pname->c.str.chars),strlen((char*)(p->c.sym.pname->c.str.chars)),lisppkg),cons(ctx,scb,args));
+    vpop(); // args
+    vpop(); // scb
   }
   ~EuslispSubscriptionCallbackHelper() {
       ROS_ERROR("subscription gc");


### PR DESCRIPTION
**I am currently testing this on my local branch and still do not advice to merge.**

When adding a subscriber in roseus, the callback function and additional arguments are stored in a lisp-package symbol to avoid being garbage collected.

The problem is that the act of storing itself is not gc-proof, and if you get unlucky enough (as I did) the additional arguments are wiped before saved, leaving a corrupted callback that leads to segmentation faults when called.

This can be solved by guarding the function and arguments on the vsp until they are successfully saved in the lisp symbol.

Of course a better solution would be having some way to guard from gc without some weird symbol in the lisp package at the first place.