### PR TITLE
[roseus_smach] add smach_viewer to run_depend

### DIFF
--- a/roseus_smach/README.md
+++ b/roseus_smach/README.md
@@ -7,7 +7,10 @@ This package includes euslisp implementation of state machine and [smach](http:/
 
 - [roseus](http://wiki.ros.org/roseus)
 - [smach](http://wiki.ros.org/smach)
-- [smach_viewer](http://wiki.ros.org/smach_viewer) (optional for visualization)
+- [smach_viewer](http://wiki.ros.org/smach_viewer)
+  - Optional for visualization.
+  - You have to install this package manually:\
+    `sudo apt install ros-$ROS_DISTRO-smach-viewer`
 
 ## sample
 


### PR DESCRIPTION
I add `smach_viewer` to run_depend in package.xml.

When I run sample codes in README, smach_viewer is not found.

Although smach_viewer is not used in scripts under src/ and sample/ directories, I think smach_viewer should be in run_depend to run README sample codes easily.