### PR TITLE
[roseus] Remove duplicated dependency in package.xml

### DIFF
--- a/roseus/package.xml
+++ b/roseus/package.xml
@@ -36,7 +36,6 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
   <build_depend>sensor_msgs</build_depend>
-  <build_depend>visualization_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>actionlib_tutorials</build_depend>
@@ -61,7 +60,6 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>std_srvs</run_depend>
   <run_depend>sensor_msgs</run_depend>
-  <run_depend>visualization_msgs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>dynamic_reconfigure</run_depend>
   <run_depend>actionlib_tutorials</run_depend>


### PR DESCRIPTION
I found duplicated dependencies in package.xml in roseus.

`<build_depend>visualization_msgs</build_depend>`
https://github.com/jsk-ros-pkg/jsk_roseus/blob/master/roseus/package.xml#L30
https://github.com/jsk-ros-pkg/jsk_roseus/blob/master/roseus/package.xml#L39

`<run_depend>visualization_msgs</run_depend>`
https://github.com/jsk-ros-pkg/jsk_roseus/blob/master/roseus/package.xml#L57
https://github.com/jsk-ros-pkg/jsk_roseus/blob/master/roseus/package.xml#L64