### PR TITLE
[eustf.l] add comment to :wait-for-transform

### DIFF
--- a/roseus/euslisp/eustf.l
+++ b/roseus/euslisp/eustf.l
@@ -212,7 +212,7 @@ $ (send tr :lookup-transform \"child\"  \"this_frame\" (ros::time))
                                (send coords :child-frame-id) auth)))
   (:wait-for-transform
    (target-frame source-frame time timeout &optional (duration 0.01))
-   "Waits for the given transformation to become available. If the timeout occurs before the transformation becomes available"
+   "Waits for the given transformation to become available. If the timeout occurs before the transformation becomes available, return nil"
    (ros::eustf-wait-for-transform cobject
                                   target-frame source-frame
                                   (send time :sec-nsec) timeout duration))


### PR DESCRIPTION
The original comment ended in the middle of the sentence.