### PR TITLE
[eustf.l] fix comment of :lookup-transform

### DIFF
--- a/roseus/euslisp/eustf.l
+++ b/roseus/euslisp/eustf.l
@@ -253,7 +253,7 @@ $ (send tr :lookup-transform \"child\"  \"this_frame\" (ros::time))
                    :nsec (cdr sec-nsec)))))
   (:lookup-transform
    (target-frame source-frame time)
-   "Returns the transform from target_frame to source_frame at time."
+   "Returns the coordinate of source_frame expressed in target_frame coordinate system at time."
    (let (ret)
      (setq ret (ros::eustf-lookup-transform cobject
                                             target-frame source-frame

--- a/roseus/euslisp/eustf.l
+++ b/roseus/euslisp/eustf.l
@@ -253,7 +253,7 @@ $ (send tr :lookup-transform \"child\"  \"this_frame\" (ros::time))
                    :nsec (cdr sec-nsec)))))
   (:lookup-transform
    (target-frame source-frame time)
-   "Returns the transform from source_frame to target_frame at time."
+   "Returns the transform from target_frame to source_frame at time."
    (let (ret)
      (setq ret (ros::eustf-lookup-transform cobject
                                             target-frame source-frame


### PR DESCRIPTION
The original comment was incorrect.
`:lookup-transform` returns the transform from **target_frame** to **source_frame**. (not from **source_frame** to **target_frame**)

https://github.com/ros/geometry/issues/108
https://answers.ros.org/question/229463/confusing-tf-transforms/
https://uenota.github.io/dronedoc/appendix/trouble_shooting/subpages/ros/reversed_tf.html
https://github.com/jsk-ros-pkg/jsk_recognition/issues/1269