### PR TITLE
[roseus_smach] use roseus for parallel-state-machine-sample

### DIFF
--- a/roseus_smach/sample/parallel-state-machine-sample.l
+++ b/roseus_smach/sample/parallel-state-machine-sample.l
@@ -1,4 +1,4 @@
-#!/usr/bin/env irteusgl
+#!/usr/bin/env roseus
 ;; parallel-state-machine-sample.l
 ;; Author: Furushchev <furushchev@jsk.imi.i.u-tokyo.ac.jp>
 


### PR DESCRIPTION
When I execute `rosrun roseus_smach parallel-state-machine-sample.l`, I got the following error.
```
Call Stack (max depth: 20):
  0: at (require :state-machine "package://roseus_smach/src/state-machine.l")
  1: at (require :state-machine "package://roseus_smach/src/state-machine.l")
irteusgl: ERROR th=0  file #P"package/roseus_smach/src/state-machine.l" not found in (require :state-machine "package://roseus_smach/src/state-machine.l")E:
```

This PR fixes this bug.