### PR TITLE
add displaying errors to action-result-cb in actionlib.l

### DIFF
--- a/roseus/euslisp/actionlib.l
+++ b/roseus/euslisp/actionlib.l
@@ -56,6 +56,10 @@
          ))))
   (:action-result-cb
    (msg)
+   ;; This error msg below will appear from a second time
+   ;; To display this error msg from the first time, use wait-interpolation or ros::spin-once
+   (if (< (send (send msg :result) :error_code) 0)
+       (ros::ros-error "~A" (send (send msg :result) :error_string)))
    (let (dummy-msg)
      (ros::ros-debug "[~A] result-cb ~A ~A" name-space (send msg :status :goal_id :id) (goal-status-to-string (send msg :status :status)))
      (unless (send comm-state :update-result msg)


### PR DESCRIPTION
I added displaying error messages in the topic `...[depending on the robots]../follow_joint_trajectory/result` to action-result-cb method. I found it good when I was running KINOVA.
This allows us to raise an error on euslisp when the robot does not work due to various reasons, such as joint angle constraints.
cc @708yamaguchi 