### PR TITLE
[roseus_smach] fix typo in state-machine-utils.l

### DIFF
--- a/roseus_smach/src/state-machine-utils.l
+++ b/roseus_smach/src/state-machine-utils.l
@@ -7,7 +7,7 @@
 Args:
   sm (state-machine): state machine
   mydata (alist): userdata for smach
-  :spin (bool, default: t): call (send sm :spin-once) every time before executing state if T, call nothing otherwise.
+  :spin (bool, default: t): call (send insp :spin-once) every time before executing state if T, call nothing otherwise.
   :hz (integer, default: 1): rate of execution loop
   :iterate (t or function): Enable asking [Y/N] on each action execution if given t, if function is given, then it is called before execution. If function returns nil, next action is not executed. Otherwise the action is executed
 


### PR DESCRIPTION
sorry, I forgot fixing this typo.
`(send sm :spin-once)` -> `(send insp :spin-once)`