### PR TITLE
[roseus_smach] Fix problems with statemachine with 10~ submachines

### DIFF
--- a/roseus_smach/src/state-machine-ros.l
+++ b/roseus_smach/src/state-machine-ros.l
@@ -27,6 +27,8 @@
    (ros::advertise
     (concatenate string srv-name "/smach/container_structure")
     smach_msgs::SmachContainerStructure 100 t) ;; latch type
+   ;; we need to sleep a bit for waiting publisher's initialization
+   ;; https://github.com/jsk-ros-pkg/jsk_roseus/pull/695
    (unix::usleep (round (* 0.5 1e6)))
    (if groupname
      (ros::subscribe (concatenate string srv-name "/smach/container_init")
@@ -89,6 +91,10 @@
    (&optional (machine sm) (path (format nil "/~A" root-name)))
    (let ((msg (instance smach_msgs::SmachContainerStructure :init))
          transitions from-nodes to-nodes exec-nodes)
+     ;; we need to sleep a bit to avoid too quick publication in the same topic name 
+     ;; :publish-structure calls :publish-structure itself inside,
+     ;; which causes to quick publication in the same topic name
+     ;; https://github.com/jsk-ros-pkg/jsk_roseus/pull/695
      (unix::usleep (round (* 0.1 1e6)))
      (send msg :header :seq (incf structure-counter))
      (send msg :header :stamp (ros::time-now))

--- a/roseus_smach/src/state-machine-ros.l
+++ b/roseus_smach/src/state-machine-ros.l
@@ -89,6 +89,7 @@
    (&optional (machine sm) (path (format nil "/~A" root-name)))
    (let ((msg (instance smach_msgs::SmachContainerStructure :init))
          transitions from-nodes to-nodes exec-nodes)
+     (unix::usleep (round (* 0.1 1e6)))
      (send msg :header :seq (incf structure-counter))
      (send msg :header :stamp (ros::time-now))
      (send msg :path path)

--- a/roseus_smach/src/state-machine-ros.l
+++ b/roseus_smach/src/state-machine-ros.l
@@ -27,6 +27,7 @@
    (ros::advertise
     (concatenate string srv-name "/smach/container_structure")
     smach_msgs::SmachContainerStructure 100 t) ;; latch type
+   (unix::usleep (round (* 0.5 1e6)))
    (if groupname
      (ros::subscribe (concatenate string srv-name "/smach/container_init")
                      smach_msgs::SmachContainerInitialStatusCmd


### PR DESCRIPTION
when I try to use statemachine with more than 10 submachines, smach_viewer cannot visualize it properly.
in this PR,
- fix the problem with the publisher init sleep problem
- avoid too quick publishication of smach structure

## this PR

![smach_multiple_submachine_after](https://user-images.githubusercontent.com/9300063/132843735-4aabc47a-a271-4a1d-9d1a-319cf405fe2b.png)

### with current master

![smach_multiple_submachine_before](https://user-images.githubusercontent.com/9300063/132843720-b1c0f260-c178-4c2c-b2bf-2fe7e0a302aa.png)