### PR TITLE
enable to run graph solver for state-machine

### DIFF
--- a/roseus_smach/src/state-machine.l
+++ b/roseus_smach/src/state-machine.l
@@ -66,14 +66,32 @@
    (&optional gs)
    (if (null gs) (return-from :goal-state goal-state))
    (if (atom gs) (setq gs (list gs)))
-   (setq gs (mapcar #'(lambda(g) (instance state :init g nil)) gs))
-   (dolist (n gs) (send self :add-node n))
+   (setq gs (mapcar #'(lambda (g)
+                        ;; g might be either state or symbol
+                        ;; if g is not found in nodes, create and add it.
+                        (if (symbolp g) ;; g is symbol
+                            (if (not (member g (send-all nodes :name))) ;; not found in ndoe
+                                (progn
+                                  (setq g (instance state :init g nil))
+                                  (send self :add-node g))
+                              (progn
+                                (setq g (mapcan #'(lambda (x) (if (eq (send x :name) g) (list x))) nodes))
+                                (if (> (length g) 1) (warning-message 2 "found multiple node for goal ~A (~A)~%" g nodes))
+                                (setq g (car g)))))
+                        (if (derivedp g state) ;; g is state
+                            (if (not (member g nodes)) ;; not found in node
+                                (progn
+                                  (send self :add-node g))
+                              (progn
+                                (setq g (mapcan #'(lambda (x) (if (eq x g) (list g))) nodes))
+                                (if (> (length g) 1) (warning-message 2 "found multiple node for goal ~A (~A)~%" g nodes))
+                                (setq g (car g)))))
+                        g)
+                    gs))
    (send-super :goal-state gs))
   (:append-goal-state (gs)
-   (if (atom gs) (setq gs (list gs)))
-   (setq gs (mapcar #'(lambda(g) (instance state :init g nil)) gs))
-   (dolist (n gs) (send self :add-node n))
-   (send-super :goal-state (append goal-state gs)))
+   (let ((org-goal-state goal-state))
+     (send-super :goal-state (append org-goal-state (send self :goal-state gs)))))
   (:goal-test (gs) (not (null (intersection (flatten (list gs)) goal-state))))
   (:goal-reached () (send self :goal-test active-state))
   ;;

--- a/roseus_smach/test/test-graph-samples.l
+++ b/roseus_smach/test/test-graph-samples.l
@@ -1,0 +1,41 @@
+(require :unittest "lib/llib/unittest.l")
+
+(load "package://roseus_smach/sample/state-machine-ros-sample.l")
+(load "package://roseus_smach/sample/parallel-state-machine-sample.l")
+
+(ros::roseus "test_roseus_smach_graph_samples")
+
+(init-unit-test)
+
+(deftest smach-graph-goal ()
+  (let (s)
+    (setq s (smach-simple2))
+    (warning-message 2 "write to /tmp/smach.pdf~%")
+    (send s :write-to-pdf "/tmp/smach.pdf" nil "smach")
+    ;; solve as graph search
+    (setq *solver* (instance breadth-first-graph-search-solver))
+
+    ;; setting start/goal state by node state
+    (send s :start-state (send s :node :bar))
+    (send s :goal-state (send s :node :outcome4))
+    (setq path (send *solver* :solve s :verbose t))
+    (warning-message 4 "solved path ~A~%" (send-all (send-all path :state) :name))
+    (assert (equal (send-all (send-all path :state) :name)
+                   '(:bar :foo :outcome4)))
+
+    ;; setting start/goal state by symbol
+    (send s :start-state :bar)
+    (send s :goal-state :outcome4)
+    ;;;
+    (send *solver* :clear-open-list) ;;; need to clear open list before you re-use *solver*
+    ;;;
+    (setq path (send *solver* :solve s :verbose t))
+    (warning-message 4 "solved path ~A~%" (send-all (send-all path :state) :name))
+    (assert (equal (send-all (send-all path :state) :name)
+                   '(:bar :foo :outcome4)))
+
+    ))
+
+(run-all-tests)
+
+(exit)

--- a/roseus_smach/test/test_samples.test
+++ b/roseus_smach/test/test_samples.test
@@ -3,4 +3,7 @@
   <test test-name="test_roseus_smach_samples" pkg="roseus" type="roseus"
         args="$(find roseus_smach)/test/test-samples.l"
         time-limit="120" />
+  <test test-name="test_roseus_smach_graph_samples" pkg="roseus" type="roseus"
+        args="$(find roseus_smach)/test/test-graph-samples.l"
+        time-limit="120" />
 </launch>


### PR DESCRIPTION
Since `state-machine` class inherits `graph` class so it should be solved by `graph-solver`
```
(load "package://roseus_smach/sample/state-machine-ros-sample.l")
(setq s (smach-simple2))

;; solve as graph search                                                                                                                            
(setq *solver* (instance breadth-first-graph-search-solver))

;; setting start/goal state by node state                                                                                                           
(send s :start-state (send s :node :bar))
(send s :goal-state (send s :node :outcome4))
(setq path (send *solver* :solve s :verbose t))
```
but this code does not return the result. Why?
```
open-list is nil... -- :solve --
search was missed!! -- :solve --
```

===
https://github.com/jsk-ros-pkg/jsk_roseus/blob/23ca528b5283792409920e8f35a50e756dad6ce8/roseus_smach/src/state-machine.l#L65-L71

`(send s :goal-state (send s :node :bar))`
generate new `state` instance and add to node, this will break graph structure. For example, if we call

```
(setq s (smach-simple2))
(send s :write-to-pdf "/tmp/smach.pdf" nil "smach")
```
the structure look like this
![smach3-1](https://user-images.githubusercontent.com/493276/140020274-395e2ebf-b7ed-498b-b57b-40dfbdd01096.png)

but if we call
```
(send s :goal-state :outcome4)
```
![smach2-1](https://user-images.githubusercontent.com/493276/140020332-e5b06a14-c15e-4b1a-9808-e2c847e2256b.png)

and if we call
```
(send s :goal-state (send s :node :outcome4))
```
![smach-1](https://user-images.githubusercontent.com/493276/140020385-1cd4e464-0368-47c1-825d-65dc5e107afb.png)

===

This change will brake existing behavior of `:goal-state` and `:append-goal-state` and I am afraid it breaks @knorth55 's program for Ph.D thesis.

Cc: @Kanazawanaoaki 