### PR TITLE
[WIP] [roseus_tutorials] add tf bbox sample

### DIFF
--- a/roseus_tutorials/src/display-tf-bounding-box-array.l
+++ b/roseus_tutorials/src/display-tf-bounding-box-array.l
@@ -1,0 +1,42 @@
+#!/usr/bin/env roseus
+
+(ros::load-ros-manifest "jsk_recognition_msgs")
+(defvar *base-frame-id* "/base_footprint")
+(defvar *camera-frame-id* "/head_mount_kinect_rgb_optical_frame")
+
+(defun bounding-box-array-cb (msg)
+  (let ((bounding-box-list (send msg :boxes)))
+    (when bounding-box-list
+      (send *irtviewer* :draw-objects :flush nil)
+      (mapcar
+       #'(lambda (b)
+           (let* ((dims (ros::tf-point->pos (send b :dimensions)))
+                  (bx (make-cube (elt dims 0) (elt dims 1) (elt dims 2)))
+                  ;; Convert geoometry_msgs::Pose of BoundingBox to euslisp coordinates [mm]
+                  (cam->obj-coords (ros::tf-pose->coords (send b :pose)))
+                  ;; Get camera coordinates [mm]
+                  (cam-coords (send *tfl* :lookup-transform
+                            *base-frame-id* (send msg :header :frame_id)
+                            (ros::time 0))))
+              ;; Get BoundingBox world coordinates [mm]
+              (send bx :transform 
+                    (send (send cam-coords :copy-worldcoords) 
+                          :transform cam->obj-coords))
+              (send bx :draw-on :flush nil :color #f(1 0 0))
+             bx))
+       bounding-box-list)
+      (send *irtviewer* :viewer :viewsurface :flush)
+      )))
+
+(ros::roseus "bounding_box_array_subscriber")
+(setq *tfl* (instance ros::transform-listener :init))
+(unless (boundp '*irtviewer*) (make-irtviewer))
+
+(ros::subscribe "~input_box" jsk_recognition_msgs::BoundingBoxArray
+                #'bounding-box-array-cb 1)
+(do-until-key
+ (x::window-main-one)
+ (ros::spin-once)
+ (ros::sleep)
+ )
+


### PR DESCRIPTION
Add sample a script which subscribes BoundingBoxArray and converts it to world coordinates.

This is an extention of https://github.com/jsk-ros-pkg/jsk_roseus/blob/b8a4ba68aecfdcad8eacb836c2f6efe93c858d88/roseus_tutorials/src/display-bounding-box-array.l.

Note that when getting the `cam-coords`, we use `lookup-transform` .
This is because we expect to move `cam-coords`.
If your camera coordinates is fixed, use `cam-coords (send (send *pr2* :head_mount_kinect_rgb_optical_frame_lk) :copy-worldcoords)))` instead.