### PR TITLE
Ignore auto-generated defun.h

### DIFF
--- a/roseus/.gitignore
+++ b/roseus/.gitignore
@@ -1,3 +1,4 @@
 bin/roseus
 euslisp/*.so
 test/simple_execute_ref_server
+defun.h

--- a/roseus/defun.h
+++ b/roseus/defun.h
@@ -1,1 +1,0 @@
-// redefine defun for update defun() API (https://github.com/euslisp/EusLisp/pull/116)


### PR DESCRIPTION
`defun.h` is auto-generated during the build, but was added in https://github.com/jsk-ros-pkg/jsk_roseus/pull/702

In this PR I am reverting this and adding the `defun.h` to gitignore.