### PR TITLE
[roseus_smach] add exit-state in state-machine and execute exit-state when Ctrl-C

### DIFF
--- a/roseus_smach/sample/sample_smach_exit_state.launch
+++ b/roseus_smach/sample/sample_smach_exit_state.launch
@@ -1,8 +1,12 @@
 <launch>
   <arg name="gui" default="true" />
+  <arg name="userdata" default="true" />
 
   <node name="exec_smach_exit_state" pkg="roseus_smach" type="state-machine-ros-sample.l"
-        args="&quot;(exec-smach-exit-state)&quot;" output="screen" />
+        args="&quot;(exec-smach-exit-state)&quot;" unless="$(arg userdata)" output="screen" />
+
+  <node name="exec_smach_userdata_exit_state" pkg="roseus_smach" type="state-machine-ros-sample.l"
+        args="&quot;(exec-smach-userdata-exit-state)&quot;" if="$(arg userdata)" output="screen" />
 
   <node name="$(anon smach_viewer)" pkg="smach_viewer" type="smach_viewer.py"
         if="$(arg gui)" />

--- a/roseus_smach/sample/sample_smach_exit_state.launch
+++ b/roseus_smach/sample/sample_smach_exit_state.launch
@@ -1,0 +1,10 @@
+<launch>
+  <arg name="gui" default="true" />
+
+  <node name="exec_smach_exit_state" pkg="roseus_smach" type="state-machine-ros-sample.l"
+        args="&quot;(exec-smach-exit-state)&quot;" output="screen" />
+
+  <node name="$(anon smach_viewer)" pkg="smach_viewer" type="smach_viewer.py"
+        if="$(arg gui)" />
+
+</launch>

--- a/roseus_smach/sample/state-machine-ros-sample.l
+++ b/roseus_smach/sample/state-machine-ros-sample.l
@@ -46,5 +46,6 @@
 (defun exec-smach-simple () (setq count 0) (exec-state-machine (smach-simple)))
 (defun exec-smach-nested () (setq count 0) (exec-state-machine (smach-nested)))
 (defun exec-smach-userdata () (exec-state-machine (smach-userdata) '((count . 1))))
+(defun exec-smach-exit-state () (setq count 0) (exec-state-machine (smach-simple) nil :exit-state :BAR))
 
-(warn ";;(exec-smach-simple)~%;;(exec-smach-nested)~%;;(exec-smach-userdata)~%")
+(warn ";;(exec-smach-simple)~%;;(exec-smach-nested)~%;;(exec-smach-userdata)~%;;(exec-smach-exit-state)~%")

--- a/roseus_smach/sample/state-machine-ros-sample.l
+++ b/roseus_smach/sample/state-machine-ros-sample.l
@@ -47,5 +47,7 @@
 (defun exec-smach-nested () (setq count 0) (exec-state-machine (smach-nested)))
 (defun exec-smach-userdata () (exec-state-machine (smach-userdata) '((count . 1))))
 (defun exec-smach-exit-state () (setq count 0) (exec-state-machine (smach-simple) nil :exit-state :BAR))
+(defun exec-smach-exit-state () (setq count 0) (exec-state-machine (smach-simple) nil :exit-state :BAR))
+(defun exec-smach-userdata-exit-state () (setq count 0) (exec-state-machine (smach-userdata) '((count . 1)) :exit-state :BAR))
 
-(warn ";;(exec-smach-simple)~%;;(exec-smach-nested)~%;;(exec-smach-userdata)~%;;(exec-smach-exit-state)~%")
+(warn ";;(exec-smach-simple)~%;;(exec-smach-nested)~%;;(exec-smach-userdata)~%;;(exec-smach-exit-state)~%;;(exec-smach-userdata-exit-state)~%")

--- a/roseus_smach/src/state-machine-ros.l
+++ b/roseus_smach/src/state-machine-ros.l
@@ -14,7 +14,7 @@
 (defclass state-machine-inspector
   :super propertied-object
   :slots (sm root-name srv-name init-tm state-counter structure-counter
-             groupname))
+             groupname exit-state))
 (defmethod state-machine-inspector
   (:init
    (sm-obj &key ((:root-name rn) "SM_ROOT") ((:srv-name sn) "/server_name") ((:groupname gp)))
@@ -143,8 +143,11 @@
      ))
   (:register-exit-signal-hook
     (&optional es userdata)
-    (if (null es) (return-from :exit-state (send sm :exit-state)))
-    (setq es (send sm :exit-state es))
+    (if (null es) (return-from :exit-state exit-state))
+    (if (null (derivedp es state))
+      (setq es (send self :state-machine :node es)))
+    ;; update exit-state slot
+    (setq exit-state es)
     (let ((exit-signal-hook
             `(lambda-closure nil 0 0 (sig code)
                (send ,self :exit-signal-hook sig code ,es ,userdata))))

--- a/roseus_smach/src/state-machine-ros.l
+++ b/roseus_smach/src/state-machine-ros.l
@@ -141,9 +141,9 @@
      ;; TODO apply userdata
      (setq init-tm (ros::time-now))
      ))
+  (:exit-state () exit-state)
   (:register-exit-signal-hook
-    (&optional es userdata exit-signal-hook-func)
-    (if (null es) (return-from :exit-state exit-state))
+    (es userdata exit-signal-hook-func)
     (if (null (derivedp es state))
       (setq es (send self :state-machine :node es)))
     ;; update exit-state slot

--- a/roseus_smach/src/state-machine-ros.l
+++ b/roseus_smach/src/state-machine-ros.l
@@ -14,7 +14,7 @@
 (defclass state-machine-inspector
   :super propertied-object
   :slots (sm root-name srv-name init-tm state-counter structure-counter
-             groupname exit-state))
+             groupname exit-state exit-signal-hook))
 (defmethod state-machine-inspector
   (:init
    (sm-obj &key ((:root-name rn) "SM_ROOT") ((:srv-name sn) "/server_name") ((:groupname gp)))
@@ -142,6 +142,7 @@
      (setq init-tm (ros::time-now))
      ))
   (:exit-state () exit-state)
+  (:exit-signal-hook () exit-signal-hook)
   (:register-exit-signal-hook
     (es userdata exit-signal-hook-func)
     (if (null (derivedp es state))
@@ -149,14 +150,18 @@
     ;; update exit-state slot
     (setq exit-state es)
     (send self :put 'userdata userdata)
-    (let ((exit-signal-hook
-            `(lambda-closure nil 0 0 (sig code)
-               (ros::ros-warn " Signal ~A called.~%" (unix:signal unix::sigint))
-               (ros::ros-error "Calling exit-signal-hook.~%")
-               (funcall ',exit-signal-hook-func (send ,self :get 'userdata))
-               (ros::ros-warn " Forcing transition to ~A.~%" ,es)
-               (send ,self :exit-signal-hook sig code ,es (send ,self :get 'userdata)))))
-      (unix:signal unix::sigint exit-signal-hook)))
+    ;; we need to set exit-signal-hook in slot
+    ;; to avoid memory error, GC causes this error?
+    (setq exit-signal-hook
+          `(lambda-closure nil 0 0 (sig code)
+             (ros::ros-warn " Signal ~A called." unix::sigint)
+             (ros::ros-warn "Calling exit-signal-hook.")
+             (funcall ',exit-signal-hook-func (send ,self :get 'userdata))
+             (ros::ros-warn " Forcing transition to ~A." ,es)
+             (send ,self :exit-signal-hook sig code ,es (send ,self :get 'userdata))
+             ))
+    (unix:signal unix::sigint exit-signal-hook)
+    )
   (:exit-signal-hook (sig code &optional es userdata)
     (if (null es) (return-from :exit-signal-hook (exit sig)))
     (send sm :active-state es)

--- a/roseus_smach/src/state-machine-ros.l
+++ b/roseus_smach/src/state-machine-ros.l
@@ -161,7 +161,7 @@
     (ros::ros-warn " Force transit to ~A.~%" es)
     (send sm :active-state es)
     (send self :publish-status userdata)
-    (unix:signal unix::sigint 'ros::roseus-sigint-handler)  ;; if C-c twise, kill roseus
+    (unix:signal unix::sigint 'ros::roseus-sigint-handler)  ;; if C-c twice, kill roseus
     )
   ;;
   ;; utility for users

--- a/roseus_smach/src/state-machine-ros.l
+++ b/roseus_smach/src/state-machine-ros.l
@@ -151,14 +151,14 @@
     (send self :put 'userdata userdata)
     (let ((exit-signal-hook
             `(lambda-closure nil 0 0 (sig code)
+               (ros::ros-warn " Signal ~A called.~%" (unix:signal unix::sigint))
+               (ros::ros-error "Calling exit-signal-hook.~%")
                (funcall ',exit-signal-hook-func (send ,self :get 'userdata))
+               (ros::ros-warn " Forcing transition to ~A.~%" ,es)
                (send ,self :exit-signal-hook sig code ,es (send ,self :get 'userdata)))))
       (unix:signal unix::sigint exit-signal-hook)))
   (:exit-signal-hook (sig code &optional es userdata)
     (if (null es) (return-from :exit-signal-hook (exit sig)))
-    (ros::ros-error "exit-signal-hook called.~%")
-    (ros::ros-warn " Called ~A~%" (unix:signal unix::sigint))
-    (ros::ros-warn " Force transit to ~A.~%" es)
     (send sm :active-state es)
     (send self :publish-status userdata)
     (unix:signal unix::sigint 'ros::roseus-sigint-handler)  ;; if C-c twice, kill roseus

--- a/roseus_smach/src/state-machine-ros.l
+++ b/roseus_smach/src/state-machine-ros.l
@@ -142,7 +142,7 @@
      (setq init-tm (ros::time-now))
      ))
   (:register-exit-signal-hook
-    (&optional es userdata)
+    (&optional es userdata exit-signal-hook-func)
     (if (null es) (return-from :exit-state exit-state))
     (if (null (derivedp es state))
       (setq es (send self :state-machine :node es)))
@@ -151,19 +151,18 @@
     (send self :put 'userdata userdata)
     (let ((exit-signal-hook
             `(lambda-closure nil 0 0 (sig code)
+               (funcall ',exit-signal-hook-func (send ,self :get 'userdata))
                (send ,self :exit-signal-hook sig code ,es (send ,self :get 'userdata)))))
-      (unix:signal 2 exit-signal-hook)
-      (unix:signal 9 exit-signal-hook)
-      (unix:signal 15 exit-signal-hook)))
+      (unix:signal unix::sigint exit-signal-hook)))
   (:exit-signal-hook (sig code &optional es userdata)
     (if (null es) (return-from :exit-signal-hook (exit sig)))
     (ros::ros-error "exit-signal-hook called.~%")
+    (ros::ros-warn " Called ~A~%" (unix:signal unix::sigint))
+    (ros::ros-warn " Force transit to ~A.~%" es)
     (send sm :active-state es)
-    (send sm :append-goal-state es)
     (send self :publish-status userdata)
-    (send sm :execute userdata :step -1)
-    (ros::ros-error "exit-signal-hook finished.~%")
-    (exit sig))
+    (unix:signal unix::sigint 'ros::roseus-sigint-handler)  ;; if C-c twise, kill roseus
+    )
   ;;
   ;; utility for users
   ;;

--- a/roseus_smach/src/state-machine-ros.l
+++ b/roseus_smach/src/state-machine-ros.l
@@ -147,19 +147,19 @@
     (setq es (send sm :exit-state es))
     (let ((exit-signal-hook
             `(lambda-closure nil 0 0 (sig code)
-               (send ,self :exit-signal-hook ,es ,userdata))))
+               (send ,self :exit-signal-hook sig code ,es ,userdata))))
       (unix:signal 2 exit-signal-hook)
       (unix:signal 9 exit-signal-hook)
       (unix:signal 15 exit-signal-hook)))
-  (:exit-signal-hook (&optional es userdata)
-    (if (null es) (return-from :exit-signal-hook (exit)))
+  (:exit-signal-hook (sig code &optional es userdata)
+    (if (null es) (return-from :exit-signal-hook (exit sig)))
     (ros::ros-error "exit-signal-hook called.~%")
     (send sm :active-state es)
     (send sm :append-goal-state es)
     (send self :publish-status userdata)
     (send sm :execute userdata :step -1)
     (ros::ros-error "exit-signal-hook finished.~%")
-    (exit))
+    (exit sig))
   ;;
   ;; utility for users
   ;;

--- a/roseus_smach/src/state-machine-ros.l
+++ b/roseus_smach/src/state-machine-ros.l
@@ -148,9 +148,10 @@
       (setq es (send self :state-machine :node es)))
     ;; update exit-state slot
     (setq exit-state es)
+    (send self :put 'userdata userdata)
     (let ((exit-signal-hook
             `(lambda-closure nil 0 0 (sig code)
-               (send ,self :exit-signal-hook sig code ,es ,userdata))))
+               (send ,self :exit-signal-hook sig code ,es (send ,self :get 'userdata)))))
       (unix:signal 2 exit-signal-hook)
       (unix:signal 9 exit-signal-hook)
       (unix:signal 15 exit-signal-hook)))

--- a/roseus_smach/src/state-machine-ros.l
+++ b/roseus_smach/src/state-machine-ros.l
@@ -141,6 +141,25 @@
      ;; TODO apply userdata
      (setq init-tm (ros::time-now))
      ))
+  (:register-exit-signal-hook
+    (&optional es userdata)
+    (if (null es) (return-from :exit-state (send sm :exit-state)))
+    (setq es (send sm :exit-state es))
+    (let ((exit-signal-hook
+            `(lambda-closure nil 0 0 (sig code)
+               (send ,self :exit-signal-hook ,es ,userdata))))
+      (unix:signal 2 exit-signal-hook)
+      (unix:signal 9 exit-signal-hook)
+      (unix:signal 15 exit-signal-hook)))
+  (:exit-signal-hook (&optional es userdata)
+    (if (null es) (return-from :exit-signal-hook (exit)))
+    (ros::ros-error "exit-signal-hook called.~%")
+    (send sm :active-state es)
+    (send sm :append-goal-state es)
+    (send self :publish-status userdata)
+    (send sm :execute userdata :step -1)
+    (ros::ros-error "exit-signal-hook finished.~%")
+    (exit))
   ;;
   ;; utility for users
   ;;

--- a/roseus_smach/src/state-machine-utils.l
+++ b/roseus_smach/src/state-machine-utils.l
@@ -2,7 +2,8 @@
 
 (defun exec-state-machine (sm &optional (mydata '(nil))
                            &key (spin t) (hz 1) (root-name "SM_ROOT") (srv-name "/server_name")
-                                iterate exit-state)
+                                iterate exit-state
+                                (exit-signal-hook-func '(lambda-closure nil 0 0 (userdata))))
   "Execute state machine
 
 Args:
@@ -11,7 +12,8 @@ Args:
   :spin (bool, default: t): call (send insp :spin-once) every time before executing state if T, call nothing otherwise.
   :hz (integer, default: 1): rate of execution loop
   :iterate (t or function): Enable asking [Y/N] on each action execution if given t, if function is given, then it is called before execution. If function returns nil, next action is not executed. Otherwise the action is executed
-  :exit-state (state or symbol): register smach's exit state for signals like sigint, sigterm and sigkill
+  :exit-state (state or symbol): register smach's exit state when cathing sigint signal
+  :exit-signal-hook-func (function): custom function when calling exit-state. Due to https://github.com/jsk-ros-pkg/jsk_roseus/issues/666#issuecomment-843640159 issue, you need to use '(lambda-closure nil 0 0 (userdata) ... , instead of #'(lambda (userdata) ...
 
 Returns:
   the last active state
@@ -22,7 +24,7 @@ Returns:
     (send insp :publish-structure) ;; publish once and latch
     (apply #'send sm :arg-keys (union (send sm :arg-keys) (mapcar #'car mydata)))
     (if exit-state
-      (send insp :register-exit-signal-hook exit-state mydata))
+      (send insp :register-exit-signal-hook exit-state mydata exit-signal-hook-func))
 
     (ros::rate hz)
     (while (ros::ok)

--- a/roseus_smach/src/state-machine-utils.l
+++ b/roseus_smach/src/state-machine-utils.l
@@ -12,7 +12,7 @@ Args:
   :spin (bool, default: t): call (send insp :spin-once) every time before executing state if T, call nothing otherwise.
   :hz (integer, default: 1): rate of execution loop
   :iterate (t or function): Enable asking [Y/N] on each action execution if given t, if function is given, then it is called before execution. If function returns nil, next action is not executed. Otherwise the action is executed
-  :exit-state (state or symbol): register smach's exit state when cathing sigint signal
+  :exit-state (state or symbol): register smach's exit state when catching sigint signal
   :exit-signal-hook-func (function): custom function when calling exit-state. Due to https://github.com/jsk-ros-pkg/jsk_roseus/issues/666#issuecomment-843640159 issue, you need to use '(lambda-closure nil 0 0 (userdata) ... , instead of #'(lambda (userdata) ...
 
 Returns:

--- a/roseus_smach/src/state-machine-utils.l
+++ b/roseus_smach/src/state-machine-utils.l
@@ -1,7 +1,8 @@
 ;; state-machine-utils.l
 
 (defun exec-state-machine (sm &optional (mydata '(nil))
-                           &key (spin t) (hz 1) (root-name "SM_ROOT") (srv-name "/server_name") iterate)
+                           &key (spin t) (hz 1) (root-name "SM_ROOT") (srv-name "/server_name")
+                                iterate exit-state)
   "Execute state machine
 
 Args:
@@ -10,6 +11,7 @@ Args:
   :spin (bool, default: t): call (send insp :spin-once) every time before executing state if T, call nothing otherwise.
   :hz (integer, default: 1): rate of execution loop
   :iterate (t or function): Enable asking [Y/N] on each action execution if given t, if function is given, then it is called before execution. If function returns nil, next action is not executed. Otherwise the action is executed
+  :exit-state (state or symbol): register smach's exit state for signals like sigint, sigterm and sigkill
 
 Returns:
   the last active state
@@ -19,6 +21,8 @@ Returns:
     (send sm :reset-state)
     (send insp :publish-structure) ;; publish once and latch
     (apply #'send sm :arg-keys (union (send sm :arg-keys) (mapcar #'car mydata)))
+    (if exit-state
+      (send insp :register-exit-signal-hook exit-state mydata))
 
     (ros::rate hz)
     (while (ros::ok)

--- a/roseus_smach/src/state-machine.l
+++ b/roseus_smach/src/state-machine.l
@@ -15,7 +15,9 @@
 (defclass state-machine
   :super graph
   :slots (active-state arg-keys
-          parallel-action-p parallel-exec-result parallel-trans-test))
+          parallel-action-p parallel-exec-result parallel-trans-test
+          exit-state))
+
 (defmethod state-machine
   (:init (&key (parallel nil))
      (setq parallel-action-p parallel)
@@ -89,6 +91,12 @@
    (send-super :goal-state (append goal-state gs)))
   (:goal-test (gs) (not (null (intersection (flatten (list gs)) goal-state))))
   (:goal-reached () (send self :goal-test active-state))
+  (:exit-state
+    (&optional es)
+    (if (null es) (return-from :exit-state exit-state))
+    (if (null (derivedp es state)) (setq es (send self :node es)))
+    (setq exit-state es)
+    exit-state)
   ;;
   (:sub-sm-node () (remove-if-not #'(lambda(n)(send n :submachine)) nodes))
   ;; @ from,to: state instance or its name

--- a/roseus_smach/src/state-machine.l
+++ b/roseus_smach/src/state-machine.l
@@ -169,9 +169,10 @@
          (warning-message 3 "Concurent state '~A' retuned outcome '~A' on termination~%"
                           (send (elt active-state i) :name) (elt ret i)))
        (warning-message 3 "Concurrent Outcomes ~A~%" (mapcar #'(lambda (s r) (cons (send s :name) r)) active-state ret)))
-     (warning-message 3 "State machine ~A '~A' :'~A' --> '~A'~%"
+     (warning-message 3 "State machine ~A '~A' :'~A' --> '~A'~A~%"
                       (if (send self :goal-test next-active-state) "terminating" "transitioning")
-                      (send-all active-state :name) (send-all (flatten trans-list) :name) (send-all next-active-state :name))
+                      (send-all active-state :name) (send-all (flatten trans-list) :name) (send-all next-active-state :name)
+                      (if userdata (format nil " with userdata '~A'" userdata) ""))
      (setq active-state (unique next-active-state))
      ret))
 

--- a/roseus_smach/src/state-machine.l
+++ b/roseus_smach/src/state-machine.l
@@ -15,9 +15,7 @@
 (defclass state-machine
   :super graph
   :slots (active-state arg-keys
-          parallel-action-p parallel-exec-result parallel-trans-test
-          exit-state))
-
+          parallel-action-p parallel-exec-result parallel-trans-test))
 (defmethod state-machine
   (:init (&key (parallel nil))
      (setq parallel-action-p parallel)
@@ -91,12 +89,6 @@
    (send-super :goal-state (append goal-state gs)))
   (:goal-test (gs) (not (null (intersection (flatten (list gs)) goal-state))))
   (:goal-reached () (send self :goal-test active-state))
-  (:exit-state
-    (&optional es)
-    (if (null es) (return-from :exit-state exit-state))
-    (if (null (derivedp es state)) (setq es (send self :node es)))
-    (setq exit-state es)
-    exit-state)
   ;;
   (:sub-sm-node () (remove-if-not #'(lambda(n)(send n :submachine)) nodes))
   ;; @ from,to: state instance or its name


### PR DESCRIPTION
I add `exit-state` and `register-signal-exit-state` to execute exit-state when Ctrl-C pressed.
You can try with this launch + diff

```xml
<launch>
  <node pkg="roseus_smach" type="state-machine-ros-sample.l" name="state_machine_ros_sample"
        args="&quot;(exec-smach-simple)&quot;" output="screen" />
</launch>
```

```diff
diff --git a/roseus_smach/sample/state-machine-ros-sample.l b/roseus_smach/sample/state-machine-ros-sample.l
index f6b24e3..95da645 100755
--- a/roseus_smach/sample/state-machine-ros-sample.l
+++ b/roseus_smach/sample/state-machine-ros-sample.l
@@ -43,7 +43,7 @@

     sm ))

-(defun exec-smach-simple () (setq count 0) (exec-state-machine (smach-simple)))
+(defun exec-smach-simple () (setq count 0) (exec-state-machine (smach-simple) nil :exit-state :bar))
 (defun exec-smach-nested () (setq count 0) (exec-state-machine (smach-nested)))
 (defun exec-smach-userdata () (exec-state-machine (smach-userdata) '((count . 1))))
```

```
$ roslaunch ./spam.launch
... logging to /home/knorth55/.ros/log/961a5da6-097b-11ed-b140-507b9d9efafc/roslaunch-melodic-p50-10801.log
Checking log directory for disk usage. This may take a while.
Press Ctrl-C to interrupt
WARNING: disk usage in log directory [/home/knorth55/.ros/log] is over 1GB.
It's recommended that you use the 'rosclean' command.

started roslaunch server http://melodic-p50:42833/

SUMMARY
========

PARAMETERS
 * /rosdistro: melodic
 * /rosversion: 1.14.12

NODES
  /
    state_machine_ros_sample (roseus_smach/state-machine-ros-sample.l)

auto-starting new master
process[master]: started with pid [10818]
ROS_MASTER_URI=http://localhost:11311

setting /run_id to 961a5da6-097b-11ed-b140-507b9d9efafc
process[rosout-1]: started with pid [10836]
started core service [/rosout]
process[state_machine_ros_sample-2]: started with pid [10843]
configuring by "/home/knorth55/install/jskeus/eus/lib/eusrt.l"
;; readmacro ;; object ;; packsym ;; common ;; constants ;; stream ;; string ;; loader ;; pprint ;; process ;; hashtab ;; array ;; mathtran ;; eusdebug ;; eusforeign ;; extnum ;; coordinates ;; tty ;; history ;; toplevel ;; trans ;; comp ;; builtins ;; par ;; intersection ;; geoclasses ;; geopack ;; geobody ;; primt ;; compose ;; polygon ;; viewing ;; viewport ;; viewsurface ;; hid ;; shadow ;; bodyrel ;; dda ;; helpsub ;; eushelp ;; xforeign ;; Xdecl ;; Xgraphics ;; Xcolor ;; Xeus ;; Xevent ;; Xpanel ;; Xitem ;; Xtext ;; Xmenu ;; Xscroll ;; Xcanvas ;; Xtop ;; Xapplwin
connected to Xserver DISPLAY=:0
X events are being asynchronously monitored.
;; pixword ;; RGBHLS ;; convolve ;; piximage ;; pbmfile ;; image_correlation ;; oglforeign ;; gldecl ;; glconst ;; glforeign ;; gluconst ;; gluforeign ;; glxconst ;; glxforeign ;; eglforeign ;; eglfunc ;; glutil ;; gltexture ;; glprim ;; gleus ;; glview ;; toiv-undefined ;; fstringdouble irtmath irtutil irtc irtgeoc irtgraph gnuplotlib ___time ___pgsql irtgeo euspqp pqp irtscene irtmodel irtdyna irtrobot irtsensor irtbvh irtcollada irtstl irtwrl irtpointcloud eusbullet bullet irtcollision irtx eusjpeg euspng png irtimage irtglrgb
;; extending gcstack 0x559bc0875690[16374] --> 0x559bc0cfdb20[32748] top=3d49
irtgl irtglc irtviewer
EusLisp 9.29(0033f2e 1d16d77c) for Linux64 created on melodic-p50(Thu Jul 14 17:35:16 JST 2022)
roseus ;; loading roseus("1.7.5-13-gdd8d2c5") on euslisp((9.29 melodic-p50 Thu Jul 14 17:35:16 JST 2022 0033f2e 1d16d77c))
[ INFO] [1658466194.244351543]: install ros::roseus-sigint-handler
eustf roseus_c_util ;;(smach-simple)
;;(smach-nested)
;;(smach-userdata)
;;(exec-smach-simple)
;;(exec-smach-nested)
;;(exec-smach-userdata)
Executing state :foo
Execute state FOO
State machine transitioning '(:foo)' :'(:outcome1)' --> '(:bar)'
Executing state :bar
Execute state BAR
State machine transitioning '(:bar)' :'(:outcome2)' --> '(:foo)'
^C[state_machine_ros_sample-2] killing on exit
[ERROR] [1658466197.011942277]: exit-signal-hook called.

Executing state :bar
Execute state BAR
State machine transitioning '(:bar)' :'(:outcome2)' --> '(:foo)'
[ERROR] [1658466197.015568140]: exit-signal-hook finished.

[ INFO] [1658466197.015636078]: cell* ROSEUS_EXIT(context*, int, cell**)
[ INFO] [1658466197.015674319]: exiting roseus 2
[rosout-1] killing on exit
[master] killing on exit
shutting down processing monitor...
... shutting down processing monitor complete
done
```

cc. @k-okada @Affonso-Gui @kochigami 