### PR TITLE
add test for arm64/arm32

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -100,6 +100,17 @@ jobs:
             CONTAINER: ubuntu:20.04
             USE_DEB: source
             NOT_TEST_INSTALL : true
+          # arm
+          - ROS_DISTRO: kinetic
+            USE_DOCKER: true
+            DOCKER_IMAGE: osrf/ubuntu_armhf:xenial
+            USE_DEB: deb
+            NOT_TEST_INSTALL : true
+          - ROS_DISTRO: kinetic
+            USE_DOCKER: true
+            DOCKER_IMAGE: osrf/ubuntu_arm64:xenial
+            USE_DEB: deb
+            NOT_TEST_INSTALL : true
 
 
     container: ${{ matrix.CONTAINER }}


### PR DESCRIPTION
```
raspberrypi で32bit OSで32bitのLinuxARMのroseusを
使っていて，矢野倉先生曰く，
roseusのdeserializeのところではないかということで
下のように通信用の文字列へdoubleのバイナリイメージを
peekするところで落ちています．多分このros::ptr-が
４や８の倍数でないと落ちるというのが32bit OS ARMでの
euslispではおきています．
簡単な直し方は，
ros::bufのros:ptr-から:doubleのバイトサイズ分を８バイトの文字列s8に
コピーして，
(sys:peek s8 0 :double)
とするとそのバイトに書かれているdoubleのイメージを
受け取ることは大丈夫だろうと思います．
また，同様に:floatでも起きているので，
ARMのマシンの32bit,64bitのマシンのroseusでの
:doubleと:floatの配列のtopic通信をARMの上でテストしてみて
くれるとうれしい．
```