### PR TITLE
add before and after hook for state machine execution

### DIFF
--- a/roseus_smach/src/state-machine-utils.l
+++ b/roseus_smach/src/state-machine-utils.l
@@ -23,30 +23,31 @@ Returns:
     (apply #'send sm :arg-keys (union (send sm :arg-keys) (mapcar #'car mydata)))
 
     (ros::rate hz)
-    (while (ros::ok)
-      (when spin
-        (send insp :spin-once)
-        (if (and (boundp '*ri*) *ri*) (send *ri* :spin-once)))
-      (send insp :publish-status mydata)
-      (when (send sm :goal-reached)
-        (return))
-      (when iterate
-        (cond
-          ((functionp iterate)
-           (unless (funcall iterate (send sm :active-state))
-             (ros::ros-warn "set abort in iteration")
-             (return))
-          (iterate
-           (unless (y-or-n-p (format nil "Execute ~A ? "
-                                     (send (send sm :active-state) :name)))
-             (ros::ros-warn "aborting...")
-             (return))
-          (t (error "value of key :iterate must be t or function"))))))
-      (if before-hook-func (funcall before-hook-func))
-      (send sm :execute mydata :step -1)
-      (if after-hook-func (funcall after-hook-func))
-      (ros::sleep))
-    (send sm :active-state)))
+    (catch :exec-state-machine-loop
+      (while (ros::ok)
+        (when spin
+          (send insp :spin-once)
+          (if (and (boundp '*ri*) *ri*) (send *ri* :spin-once)))
+        (send insp :publish-status mydata)
+        (when (send sm :goal-reached)
+          (return))
+        (when iterate
+          (cond
+            ((functionp iterate)
+             (unless (funcall iterate (send sm :active-state))
+               (ros::ros-warn "set abort in iteration")
+               (return))
+            (iterate
+             (unless (y-or-n-p (format nil "Execute ~A ? "
+                                       (send (send sm :active-state) :name)))
+               (ros::ros-warn "aborting...")
+               (return))
+            (t (error "value of key :iterate must be t or function"))))))
+        (if before-hook-func (funcall before-hook-func))
+        (send sm :execute mydata :step -1)
+        (if after-hook-func (funcall after-hook-func))
+        (ros::sleep))
+      (send sm :active-state))))
 
 (defun smach-exec (sm)
   "Deprecated function"

--- a/roseus_smach/src/state-machine-utils.l
+++ b/roseus_smach/src/state-machine-utils.l
@@ -1,7 +1,9 @@
 ;; state-machine-utils.l
 
 (defun exec-state-machine (sm &optional (mydata '(nil))
-                           &key (spin t) (hz 1) (root-name "SM_ROOT") (srv-name "/server_name") iterate)
+                           &key (spin t) (hz 1) (root-name "SM_ROOT") (srv-name "/server_name") iterate
+                           (before-hook-func) (after-hook-func)
+                           )
   "Execute state machine
 
 Args:
@@ -40,7 +42,9 @@ Returns:
              (ros::ros-warn "aborting...")
              (return))
           (t (error "value of key :iterate must be t or function"))))))
+      (if before-hook-func (funcall before-hook-func))
       (send sm :execute mydata :step -1)
+      (if after-hook-func (funcall after-hook-func))
       (ros::sleep))
     (send sm :active-state)))
 


### PR DESCRIPTION
this PR add `before-hook-func` and `after-hook-func` for state-machine execution.
in the loop, we can add befor hook and after hook for smach execution.
I also add `catch :exec-state-machine-loop` for `global exit` from the loop.

this is the example of the hook usage.

```lisp
        (exec-state-machine
          *sm* '((wait-count . nil) (clean-count . nil)
                 (other-check-count . nil) (other-clean-count . nil))
          :before-hook-func
          `(lambda-closure nil 0 0 ()
             (while (and *paused* (null *started*))
               (ros::ros-warn "Paused...")
               (ros::spin-once)
               (ros::sleep))
             (if (null *started*)
               (progn
                 (ros::ros-warn "Stopped...")
                 (throw :exec-state-machine-loop t))))
          :after-hook-func
          `(lambda-closure nil 0 0 ()
             (send *irtviewer* :draw-objects))
          )

```