### PR TITLE
[roseus] check if argv[1] is nil in `wait-for-service`

### DIFF
--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -1089,7 +1089,7 @@ pointer ROSEUS_WAIT_FOR_SERVICE(register context *ctx,int n,pointer *argv)
 
   int32_t timeout = -1;
 
-  if( n > 1 )
+  if( n > 1 && argv[1] != NIL)
     timeout = (int32_t)ckintval(argv[1]);
 
   bool bSuccess = service::waitForService(service, ros::Duration(timeout));


### PR DESCRIPTION
`(wait-for-service server-name timeout)` be called with `nil` or `negative` value.
this PR check if the `argv[1]` is `nil` or not and `positive` or not, and ignore if it is `nil` or `negative`.