### PR TITLE
Avoid setting breakpoints at other namespaces when using --gdb option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ### Run roseus on gdb
 ```
-gdb --args bash roseus foo.l
+roseus --gdb foo.l
 ```
 
 

--- a/roseus/bin/roseus.in
+++ b/roseus/bin/roseus.in
@@ -17,7 +17,7 @@ case $1 in
         shift # past argument
         GDB_OPTIONS=/tmp/roseus_gdbinit
         cat <<EOF > $GDB_OPTIONS
-break error
+break -qualified error
 commands
 where
 end


### PR DESCRIPTION
When running `$ roseus --gdb "(load \"package://pr2eus/pr2-interface.l\")" "(pr2-init)"` on the simulator, the program stops at the following breakpoint.
```
Thread 3 "irteusgl" hit Breakpoint 1, 0x00007fffec8a0c20 in XmlRpc::XmlRpcUtil::error(char const*, ...)@plt () from /opt/ros/melodic/lib/libxmlrpcpp.so
#0  0x00007fffec8a0c20 in XmlRpc::XmlRpcUtil::error(char const*, ...)@plt ()
   from /opt/ros/melodic/lib/libxmlrpcpp.so
#1  0x00007fffec8a1af2 in XmlRpc::XmlRpcClient::writeRequest() ()
   from /opt/ros/melodic/lib/libxmlrpcpp.so
#2  0x00007fffec8a25a6 in XmlRpc::XmlRpcClient::handleEvent(unsigned int) ()
   from /opt/ros/melodic/lib/libxmlrpcpp.so
#3  0x00007fffec8a351f in XmlRpc::XmlRpcDispatch::work(double) ()
   from /opt/ros/melodic/lib/libxmlrpcpp.so
#4  0x00007fffecfa7e38 in ros::XMLRPCManager::serverThreadFunc() ()
   from /opt/ros/melodic/lib/libroscpp.so
#5  0x00007fffec463bcd in ?? () from /usr/lib/x86_64-linux-gnu/libboost_thread.so.1.65.1
#6  0x00007ffff644e6db in start_thread (arg=0x7fffe570c700) at pthread_create.c:463
#7  0x00007ffff617761f in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```

Examining the situation, it seems that `break error` will add breakpoints to all functions named `error`, in all namespaces.

```
(gdb) info b
Num     Type           Disp Enb Address            What
1       breakpoint     keep y   <MULTIPLE>         
1.1                         y     0x00005555555c40d8 <error>
1.2                         y     0x00007fffe9edd2a0 <icu_60::RBBIRuleScanner::error(UErrorCode)>
1.3                         y     0x00007fffea30e8e0 <icu_60::RegexCompile::error(UErrorCode)>
1.4                         y     0x00007fffeb283890 <log4cxx::varia::FallbackErrorHandler::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::exception const&, int) const>
1.5                         y     0x00007fffeb283990 <virtual thunk to log4cxx::varia::FallbackErrorHandler::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::exception const&, int) const>
1.6                         y     0x00007fffeb283c90 <log4cxx::varia::FallbackErrorHandler::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::exception const&, int, log4cxx::helpers::ObjectPtrT<log4cxx::spi::LoggingEvent> const&) const>
1.7                         y     0x00007fffeb284dd0 <virtual thunk to log4cxx::varia::FallbackErrorHandler::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::exception const&, int, log4cxx::helpers::ObjectPtrT<log4cxx::spi::LoggingEvent> const&) const>
1.8                         y     0x00007fffeb285610 <log4cxx::varia::FallbackErrorHandler::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const>
1.9                         y     0x00007fffeb285620 <virtual thunk to log4cxx::varia::FallbackErrorHandler::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const>
1.10                        y     0x00007fffeb2a5a80 <log4cxx::Logger::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, log4cxx::spi::LocationInfo const&) const>
1.11                        y     0x00007fffeb2a5b30 <log4cxx::Logger::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const>
1.12                        y     0x00007fffeb2a6ba0 <log4cxx::Logger::error(std::__cxx11::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > const&, log4cxx::spi::LocationInfo const&) const>
1.13                        y     0x00007fffeb2a6c50 <log4cxx::Logger::error(std::__cxx11::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > const&) const>
1.14                        y     0x00007fffeb2aa0e0 <log4cxx::helpers::LogLog::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)>
1.15                        y     0x00007fffeb2aa3e0 <log4cxx::helpers::LogLog::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::exception const&)>
1.16                        y     0x00007fffeb2b8070 <log4cxx::helpers::OnlyOnceErrorHandler::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::exception const&, int, log4cxx::helpers::ObjectPtrT<log4cxx::spi::LoggingEvent> const&) const>
1.17                        y     0x00007fffeb2b8080 <virtual thunk to log4cxx::helpers::OnlyOnceErrorHandler::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::exception const&, int, log4cxx::helpers::ObjectPtrT<log4cxx::spi::LoggingEvent> const&) const>
1.18                        y     0x00007fffeb2b80d0 <log4cxx::helpers::OnlyOnceErrorHandler::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::exception const&, int) const>
1.19                        y     0x00007fffeb2b8100 <virtual thunk to log4cxx::helpers::OnlyOnceErrorHandler::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::exception const&, int) const>
1.20                        y     0x00007fffeb2b8110 <log4cxx::helpers::OnlyOnceErrorHandler::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const>
1.21                        y     0x00007fffeb2b8140 <virtual thunk to log4cxx::helpers::OnlyOnceErrorHandler::error(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const>
1.22                        y     0x00007fffece07c20 <XmlRpc::XmlRpcUtil::error(char const*, ...)@plt>
1.23                        y     0x00007fffece106c0 <XmlRpc::XmlRpcUtil::error(char const*, ...)>
1.24                        y     0x00007fffece116d0 <DefaultErrorHandler::error(char const*)>
1.25                        y     0x00007ffff6182740 in __error at error.c:294
```

Since I don't think we want to add breakpoints to all arbitrary functions named `error`, in this PR I am limiting the breaks to the euslisp error function, which doesn't have any namespace.

```
(gdb) info b
Num     Type           Disp Enb Address            What
1       breakpoint     keep y   <MULTIPLE>         
1.1                         y     0x00005555555c40d8 <error>
1.2                         y     0x00007ffff6182740 in __error at error.c:294
```

https://sourceware.org/gdb/onlinedocs/gdb/Explicit-Locations.html