### PR TITLE
[roseus] use float for waitForService

### DIFF
--- a/roseus/roseus.cpp
+++ b/roseus/roseus.cpp
@@ -1082,15 +1082,16 @@ pointer ROSEUS_WAIT_FOR_SERVICE(register context *ctx,int n,pointer *argv)
 {
   isInstalledCheck;
   string service;
+  numunion nu;
 
   ckarg2(1,2);
   if (isstring(argv[0])) service = ros::names::resolve((char *)get_string(argv[0]));
   else error(E_NOSTRING);
 
-  int32_t timeout = -1;
+  float timeout = -1;
 
   if( n > 1 )
-    timeout = (int32_t)ckintval(argv[1]);
+    timeout = ckfltval(argv[1]);
 
   bool bSuccess = service::waitForService(service, ros::Duration(timeout));
 


### PR DESCRIPTION
This PR supports float value for `wait-for-service`


### This PR

```
2.irteusgl$ (bench (ros::wait-for-service "/hoge" 0.1))
[ INFO] [1669893179.246469328]: waitForService: Service [/hoge] has not been advertised, waiting...
;; time -> 0.112254[s]
nil
3.irteusgl$ (bench (ros::wait-for-service "/hoge" 0.5))
[ INFO] [1669893182.724133362]: waitForService: Service [/hoge] has not been advertised, waiting...
;; time -> 0.500441[s]
nil
4.irteusgl$ (bench (ros::wait-for-service "/hoge" 1.7))
[ INFO] [1669893188.485341099]: waitForService: Service [/hoge] has not been advertised, waiting...
;; time -> 1.70549[s]
nil
5.irteusgl$ (bench (ros::wait-for-service "/hoge" 2))
[ INFO] [1669893198.351550769]: waitForService: Service [/hoge] has not been advertised, waiting...
;; time -> 2.00875[s]
nil
```

### Current master

```
2.irteusgl$ (bench (ros::wait-for-service "/hoge" 0.1))
Call Stack (max depth: 20):
  0: at (ros::wait-for-service "/hoge" 0.1)
  1: at (progn (ros::wait-for-service "/hoge" 0.1))
  2: at (let ((#:prog1365 (progn (ros::wait-for-service "/hoge" 0.1)))) (progn (format t ";; ~A -> ~A[s]~%" #:dotimes363 (send #:dotimes362 :stop))) #:prog1365)
  3: at (prog1 (progn (ros::wait-for-service "/hoge" 0.1)) (format t ";; ~A -> ~A[s]~%" #:dotimes363 (send #:dotimes362 :stop)))
  4: at (let ((#:dotimes362 (instance mtimer :init)) (#:dotimes363 "time")) (send #:dotimes362 :start) (prog1 (progn (ros::wait-for-service "/hoge" 0.1)) (format t ";; ~A -> ~A[s]~%" #:dotimes363 (send #:dotimes362 :stop))))
  5: at (bench (ros::wait-for-service "/hoge" 0.1))
  6: at #<compiled-code #X55e599e59280>
/home/knorth55/install/jskeus/eus/Linux64/bin/irteusgl 0 error: integer expected in (ros::wait-for-service "/hoge" 0.1)
```

cc. @Affonso-Gui 

related: #623 