### PR TITLE
test-add-two-ints.l:  relax test condition

### DIFF
--- a/roseus/test/test-add-two-ints.l
+++ b/roseus/test/test-add-two-ints.l
@@ -52,9 +52,9 @@
         (warning-message 3 (format nil "[~A] integration failure (~A+~A)=~A(~A)/=~A(~A)~%"
                                    service-call-error
                                    a b (+ a b) (class (+ a b)) (send res :sum) (class (send res :sum)))))
-      (assert (or (< service-call-error 3) (= (+ (send req :a) (send req :b)) (send res :sum)))
-              (format nil "integration failure (~A+~A)=~A(~A)/=~A(~A)"
-                           a b (+ a b) (class (+ a b)) (send res :sum) (class (send res :sum))))
+      (assert (or (< service-call-error 5) (= (+ (send req :a) (send req :b)) (send res :sum)))
+              (format nil "integration failure ~A times ... (~A+~A)=~A(~A)/=~A(~A)"
+                           service-call-error a b (+ a b) (class (+ a b)) (send res :sum) (class (send res :sum))))
       (sys::gc)
       )))
 


### PR DESCRIPTION
relax test condition for test-add-two-ints without persistent. we expect service call sometime fails without persistent