### PR TITLE
migrate to non-deprecated libuvc_camera

### DIFF
--- a/roseus_tutorials/launch/usb-camera.launch
+++ b/roseus_tutorials/launch/usb-camera.launch
@@ -2,7 +2,7 @@
   <arg name="device" default="/dev/video0" />
   <arg name="frame_id" default="camera"/>
   <arg name="camera_info_url" default="file://$(find roseus_tutorials)/launch/usb-camera.yaml"/>
-  <node name="uvc_camera" pkg="uvc_camera" type="uvc_camera_node" output="screen" >
+  <node name="uvc_camera" pkg="libuvc_camera" type="camera_node" output="screen" >
     <param name="device" value="$(arg device)" />
     <param name="camera_info_url" type="string" value="$(arg camera_info_url)"/>
     <param name="width" value="640" />

--- a/roseus_tutorials/package.xml
+++ b/roseus_tutorials/package.xml
@@ -19,7 +19,7 @@
 
   <build_depend>roseus</build_depend>
 
-  <run_depend>uvc_camera</run_depend>
+  <run_depend>libuvc_camera</run_depend>
   <run_depend>ar_track_alvar</run_depend>
   <run_depend>opencv_apps</run_depend>
   <!-- <run_depend>saliency_tracking<run_depend> -->


### PR DESCRIPTION
uvc_camera is not released in noetic and long (very long) deprecated. The interface *should* be compatible, but I did not run the tutorials as I have no experience with roseus.

I don't plan to build uvc_camera in ROS-O, so this fails right now.

@k-okada @knorth55 