### PR TITLE
remove euslisp from CATKIN_DEPENDS, as euslisp is not catkin package from ROS-O

### DIFF
--- a/roseus_smach/CMakeLists.txt
+++ b/roseus_smach/CMakeLists.txt
@@ -14,7 +14,7 @@ generate_messages(
 
 catkin_package(
 #    DEPENDS 
-    CATKIN_DEPENDS euslisp roseus smach smach_ros smach_msgs # TODO
+    CATKIN_DEPENDS roseus smach smach_ros smach_msgs # TODO
 #    INCLUDE_DIRS # TODO include
 #    LIBRARIES # TODO
 )


### PR DESCRIPTION
closes
```
2025-02-13T10:17:18.5985936Z -- Installing devel-space wrapper /github/home/ws/src/executive_smach_visualization/smach_viewer/test/test_rosout_error.py to /github/home/ws/devel/.private/smach_viewer/share/smach_viewer/test
2025-02-13T10:17:18.5986753Z -- Using these message generators: gencpp;geneus;genlisp;gennodejs;genpy
2025-02-13T10:17:18.5987263Z -- [roseus.cmake] loading roseus.cmake from smach_viewer
2025-02-13T10:17:18.5987550Z -- [roseus.cmake] roseus 1.7.5
2025-02-13T10:17:18.5987761Z -- [roseus.cmake] jskeus
2025-02-13T10:17:18.5987960Z -- [roseus.cmake] euslisp
2025-02-13T10:17:18.5988166Z -- [roseus.cmake] geneus 3.0.0
2025-02-13T10:17:18.5988384Z -- [roseus.cmake] genmsg 0.5.16
2025-02-13T10:17:18.5988881Z -- [roseus.cmake] message_generation Requires: gencpp;geneus;gennodejs;genlisp;genmsg;genpy
2025-02-13T10:17:18.5989612Z CMake Error at /opt/ros/one/share/roseus_smach/cmake/roseus_smachConfig.cmake:195 (find_package):
2025-02-13T10:17:18.5990137Z   Could not find a package configuration file provided by "euslisp" with any
2025-02-13T10:17:18.5990484Z   of the following names:
2025-02-13T10:17:18.5990616Z
2025-02-13T10:17:18.5990693Z     euslispConfig.cmake
2025-02-13T10:17:18.5990896Z     euslisp-config.cmake
2025-02-13T10:17:18.5991021Z
2025-02-13T10:17:18.5991192Z   Add the installation prefix of "euslisp" to CMAKE_PREFIX_PATH or set
2025-02-13T10:17:18.5991601Z   "euslisp_DIR" to a directory containing one of the above files.  If
2025-02-13T10:17:18.5992007Z   "euslisp" provides a separate development package or SDK, be sure it has
2025-02-13T10:17:18.5992333Z   been installed.
2025-02-13T10:17:18.5992527Z Call Stack (most recent call first):
2025-02-13T10:17:18.5992769Z   CMakeLists.txt:30 (find_package)
2025-02-13T10:17:18.5992919Z
```